### PR TITLE
Simpler workstack query

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -73,7 +73,7 @@ public class StageService {
 
     public Set<Stage> getActiveStages() {
         Set<UUID> teams = userPermissionsService.getUserTeams();
-        return stageRepository.findAllBy(teams, userPermissionsService.getUserId());
+        return stageRepository.findAllBy(teams);
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -19,7 +19,7 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
 
     @Query(value = "SELECT sd.* FROM active_stage sd WHERE sd.team_uuid = ?1", nativeQuery = true)
     Set<Stage> findAllByUserUUID(UUID teamUUID);
-  
-    @Query(value = "SELECT * FROM stage_data sd WHERE sd.team_uuid IN ?1 OR sd.user_uuid = ?2", nativeQuery = true)
-    Set<Stage> findAllBy(Set<UUID> teamUUID, UUID userUUID);
+
+    @Query(value = "SELECT * FROM active_stage sd WHERE sd.team_uuid IN ?1", nativeQuery = true)
+    Set<Stage> findAllBy(Set<UUID> teamUUID);
 }

--- a/src/main/resources/db/migration/postgresql/V1_1__CREATE_CASE_STAGE.sql
+++ b/src/main/resources/db/migration/postgresql/V1_1__CREATE_CASE_STAGE.sql
@@ -66,9 +66,6 @@ CREATE INDEX stage_case_uuid_complete
 CREATE INDEX stage_team_uuid_complete
   ON stage (team_uuid, case_uuid)
   WHERE status <> 'COMPLETED';
-CREATE INDEX stage_user_uuid_complete
-  ON stage (user_uuid, case_uuid)
-  WHERE status <> 'COMPLETED';
 
 CREATE OR REPLACE VIEW active_stage AS
   SELECT c.reference AS case_reference, c.type AS case_type, c.data as data, s.*

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -332,12 +332,11 @@ public class StageServiceTest {
             add(UUID.randomUUID());
         }};
 
-        when(userPermissionsService.getUserId()).thenReturn(userId);
         when(userPermissionsService.getUserTeams()).thenReturn(teams);
 
         stageService.getActiveStages();
 
-        verify(stageRepository, times(1)).findAllBy(teams, userId);
+        verify(stageRepository, times(1)).findAllBy(teams);
 
         verifyNoMoreInteractions(stageRepository);
     }


### PR DESCRIPTION
Because our business logic doesn't allow a user to own a case outside of their team, selecting just the teams will return all the users cases too, its still up to the frontend to filter these cases as it wants.