### PR TITLE
Hocs 1035 stage user and team

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -232,7 +232,7 @@ public class StageService {
             log.info("No cases - Returning 0 Stages", value(EVENT, SEARCH_STAGE_LIST_EMPTY));
             return new HashSet<>(0);
         } else {
-            Set<Stage> stages = stageRepository.findAllByCaseUUIDIn(caseUUIDs);
+            Set<Stage> stages = stageRepository.findDistinctLatest(caseUUIDs);
             log.info("Returning {} Stages", stages.size(), value(EVENT, SEARCH_STAGE_LIST_RETRIEVED));
             return groupByCaseUUID(stages);
         }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -220,7 +220,6 @@ public class StageService {
         Set<Stage> stages = stageRepository.findByCaseReference(reference);
         final Set<Stage> collect = reduceToMostActive(stages).collect(Collectors.toSet());
         if (collect.size() > 1) {
-            stages = stageRepository.findByCaseReference(reference);
             return reduceToLatest(stages).collect(Collectors.toSet());
         }
         return collect;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
@@ -99,7 +99,9 @@ public class Stage implements Serializable {
 
     public void setTeam(UUID teamUUID) {
         this.teamUUID = teamUUID;
-        this.userUUID = null;
+        if (teamUUID != null) {
+            this.userUUID = null;
+        }
     }
 
     public void setUser(UUID userUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
@@ -98,8 +98,8 @@ public class Stage implements Serializable {
     }
 
     public void setTeam(UUID teamUUID) {
-        this.teamUUID = teamUUID;
         if (teamUUID != null) {
+            this.teamUUID = teamUUID;
             this.userUUID = null;
         }
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -23,7 +23,7 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
     @Query(value = "SELECT sd.* FROM stage_data sd WHERE sd.case_uuid = ?1", nativeQuery = true)
     Set<Stage> findAllByCaseUUID(UUID caseUUID);
 
-    @Query(value = "SELECT sd.* FROM stage_data sd WHERE sd.case_uuid IN ?1", nativeQuery = true)
+    @Query(value = "SELECT sd.* FROM stage_data sd WHERE sd.user_uuid IS NULL AND sd.case_uuid IN ?1", nativeQuery = true)
     Set<Stage> findAllByCaseUUIDIn(Set<UUID> caseUUID);
 
     @Query(value = "SELECT sd.* FROM active_stage_data sd WHERE sd.team_uuid = ?1", nativeQuery = true)

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -23,9 +23,6 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
     @Query(value = "SELECT sd.* FROM stage_data sd WHERE sd.case_uuid = ?1", nativeQuery = true)
     Set<Stage> findAllByCaseUUID(UUID caseUUID);
 
-    @Query(value = "SELECT sd.* FROM stage_data sd WHERE sd.user_uuid IS NULL AND sd.case_uuid IN ?1", nativeQuery = true)
-    Set<Stage> findAllByCaseUUIDIn(Set<UUID> caseUUID);
-
     @Query(value = "SELECT sd.* FROM active_stage_data sd WHERE sd.team_uuid = ?1", nativeQuery = true)
     Set<Stage> findAllActiveByTeamUUID(UUID teamUUID);
 
@@ -37,5 +34,8 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
 
     @Query(value = "SELECT sd.* FROM stage_data sd join active_case ac on sd.case_uuid = ac.uuid where ac.reference = ?1", nativeQuery = true)
     Set<Stage> findByCaseReference(String reference);
+
+    @Query(value = "SELECT s.* from stage_data s WHERE s.case_uuid IN ?1 AND s.created = (SELECT MAX(ss.created) FROM stage_data ss WHERE ss.case_uuid = s.case_uuid)", nativeQuery = true)
+    Set<Stage> findDistinctLatest(Set<UUID> caseUUID);
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.dto.GetAuditResponse;
@@ -14,7 +15,6 @@ import uk.gov.digital.ho.hocs.casework.client.notifyclient.NotifyClient;
 import uk.gov.digital.ho.hocs.casework.client.searchClient.SearchClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
-import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.repository.StageRepository;
 import uk.gov.digital.ho.hocs.casework.security.UserPermissionsService;
@@ -35,7 +35,6 @@ public class StageServiceTest {
     private final UUID userUUID = UUID.randomUUID();
     private final UUID stageUUID = UUID.randomUUID();
     private final String stageType = "DCU_MIN_MARKUP";
-    private final LocalDate deadline = LocalDate.now();
     private final String allocationType = "anyAllocate";
     private final UUID transitionNoteUUID = UUID.randomUUID();
     private final CaseDataType caseDataType = new CaseDataType("MIN", "1a", "MIN");
@@ -461,12 +460,12 @@ public class StageServiceTest {
         SearchRequest searchRequest = new SearchRequest();
 
         when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
-        when(stageRepository.findAllByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+        when(stageRepository.findDistinctLatest(caseUUIDS)).thenReturn(stages);
 
         Set<Stage> stageResults = stageService.search(searchRequest);
 
         verify(searchClient, times(1)).search(searchRequest);
-        verify(stageRepository, times(1)).findAllByCaseUUIDIn(caseUUIDS);
+        verify(stageRepository, times(1)).findDistinctLatest(caseUUIDS);
         verifyNoMoreInteractions(searchClient);
         verifyNoMoreInteractions(stageRepository);
 
@@ -490,12 +489,12 @@ public class StageServiceTest {
         SearchRequest searchRequest = new SearchRequest();
 
         when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
-        when(stageRepository.findAllByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+        when(stageRepository.findDistinctLatest(caseUUIDS)).thenReturn(stages);
 
         Set<Stage> stageResults = stageService.search(searchRequest);
 
         verify(searchClient, times(1)).search(searchRequest);
-        verify(stageRepository, times(1)).findAllByCaseUUIDIn(caseUUIDS);
+        verify(stageRepository, times(1)).findDistinctLatest(caseUUIDS);
         verifyNoMoreInteractions(searchClient);
         verifyNoMoreInteractions(stageRepository);
 
@@ -519,12 +518,12 @@ public class StageServiceTest {
         SearchRequest searchRequest = new SearchRequest();
 
         when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
-        when(stageRepository.findAllByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+        when(stageRepository.findDistinctLatest(caseUUIDS)).thenReturn(stages);
 
         Set<Stage> stageResults = stageService.search(searchRequest);
 
         verify(searchClient, times(1)).search(searchRequest);
-        verify(stageRepository, times(1)).findAllByCaseUUIDIn(caseUUIDS);
+        verify(stageRepository, times(1)).findDistinctLatest(caseUUIDS);
         verifyNoMoreInteractions(searchClient);
         verifyNoMoreInteractions(stageRepository);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/StageTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/StageTest.java
@@ -106,7 +106,7 @@ public class StageTest {
         assertThat(stage.getCreated()).isOfAnyClassIn(LocalDateTime.now().getClass());
         assertThat(stage.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(stage.getStageType()).isEqualTo(stageType);
-        assertThat(stage.getTeamUUID()).isEqualTo(null);
+        assertThat(stage.getTeamUUID()).isNotEqualTo(null);
         assertThat(stage.getUserUUID()).isEqualTo(null);
         assertThat(stage.getDeadline()).isEqualTo(deadline);
 


### PR DESCRIPTION
The basis of stage searches and selects on the database was the fact that only the latest stage contained the team information. The meant that all the stages, except the latest, were void of team and user information and audit had to be relied upon to provide that.
Now that the team and user information is being updated correctly, the searches and selects had to be modified to return only the last stage. This is done with timestamp or by using the void user field for multiple case selects.
Although the design is to return multiple stages on the rest calls, the front end never had to process them and is not in a state to do so after trying to send multiples. The server endpoints therefore only return the latest for both search and reference find capabilities.