### PR TITLE
HOCS-1360 : task force team upload docs

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -32,7 +32,7 @@ class CaseDataResource {
         this.caseDataService = caseDataService;
     }
 
-    @Authorised(accessLevel = AccessLevel.WRITE)
+    @Authorised(accessLevel = AccessLevel.OWNER)
     @PostMapping(value = "/case")
     ResponseEntity<CreateCaseResponse> createCase(@RequestBody CreateCaseRequest request) {
         CaseData caseData = caseDataService.createCase(request.getType(), request.getData(), request.getDateRecieved());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataCreateCaseIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataCreateCaseIntegrationTest.java
@@ -79,21 +79,16 @@ public class CaseDataCreateCaseIntegrationTest {
     }
 
     @Test
-    public void shouldCreateACaseWithPermissionLevelWrite() throws JsonProcessingException {
+    public void shouldReturnUnauthorisedAndNotCreateACaseWithPermissionLevelWrite() throws JsonProcessingException {
 
         long numberOfCasesBefore = caseDataRepository.count();
-
         setupMockTeams("TEST", 3);
-        ResponseEntity<CreateCaseResponse> result = getCreateCaseResponse(createBody("TEST"), "TEST", "3");
 
-        CaseData caseData = caseDataRepository.findByUuid(result.getBody().getUuid());
+        ResponseEntity<Void> result = getCreateCaseVoidResponse(createBody("TEST"), "TEST", "3");
+
         long numberOfCasesAfter = caseDataRepository.count();
-
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(result.getBody().getReference()).isNotNull();
-        assertThat(result.getBody().getUuid()).isNotNull();
-        assertThat(caseData).isNotNull();
-        assertThat(numberOfCasesAfter).isEqualTo(numberOfCasesBefore + 1L);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(numberOfCasesAfter).isEqualTo(numberOfCasesBefore);
     }
 
     @Test


### PR DESCRIPTION
Allow task force to upload docs; creating claim requires "owner" access level. Merge to WCS.