### PR TITLE
HOCS-1551 : make document tags case type specific, fix

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/documentclient/GetDocumentsResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/documentclient/GetDocumentsResponse.java
@@ -3,7 +3,9 @@ package uk.gov.digital.ho.hocs.casework.client.documentclient;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
+import java.util.List;
 import java.util.Set;
 
 
@@ -14,4 +16,7 @@ public class GetDocumentsResponse {
     @JsonProperty("documents")
     private Set<DocumentDto> documentDtos;
 
+    @Setter
+    @JsonProperty("documentTags")
+    private List<String> documentTags;
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResourceTest.java
@@ -14,6 +14,7 @@ import uk.gov.digital.ho.hocs.casework.client.documentclient.GetDocumentsRespons
 import uk.gov.digital.ho.hocs.casework.client.documentclient.S3Document;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.UUID;
@@ -52,7 +53,7 @@ public class CaseDocumentResourceTest {
 
     @Test
     public void getDocumentsForCase() {
-        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)));
+        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)), new ArrayList<String>(Arrays.asList("ORIGINAL", "DRAFT")));
 
         when(caseDocumentService.getDocuments(caseUUID, caseType)).thenReturn(documentsResponse);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/client/documentclient/DocumentClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/client/documentclient/DocumentClientTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.casework.application.RestHelper;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.UUID;
@@ -51,7 +52,7 @@ public class DocumentClientTest {
 
     @Test
     public void getDocuments() {
-        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)));
+        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)), new ArrayList<String>(Arrays.asList("ORIGINAL", "DRAFT")));
         String url = "/document/reference/" + caseUUID.toString();
         when(restHelper.get(anyString(), anyString(), any(Class.class))).thenReturn(documentsResponse);
 
@@ -60,6 +61,10 @@ public class DocumentClientTest {
         assertThat(actualResult).isNotNull();
         assertThat(actualResult.getDocumentDtos()).isNotNull();
         assertThat(actualResult.getDocumentDtos().size()).isOne();
+        assertThat(actualResult.getDocumentTags()).isNotNull();
+        assertThat(actualResult.getDocumentTags().size()).isEqualTo(2);
+        assertThat(actualResult.getDocumentTags().get(0)).isEqualTo("ORIGINAL");
+        assertThat(actualResult.getDocumentTags().get(1)).isEqualTo("DRAFT");
         checkDocumentDto(actualResult.getDocumentDtos().iterator().next());
         verify(restHelper).get(documentService, url, GetDocumentsResponse.class);
         verifyNoMoreInteractions(restHelper);
@@ -67,7 +72,7 @@ public class DocumentClientTest {
 
     @Test
     public void getDocuments_shouldPopulateType() {
-        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)));
+        GetDocumentsResponse documentsResponse = new GetDocumentsResponse(new HashSet<>(Arrays.asList(documentDto)), new ArrayList<String>(Arrays.asList("ORIGINAL", "DRAFT")));
         String url = "/document/reference/" + caseUUID.toString() + "/?type=" + caseType;
         when(restHelper.get(anyString(), anyString(), any(Class.class))).thenReturn(documentsResponse);
 
@@ -76,6 +81,10 @@ public class DocumentClientTest {
         assertThat(actualResult).isNotNull();
         assertThat(actualResult.getDocumentDtos()).isNotNull();
         assertThat(actualResult.getDocumentDtos().size()).isOne();
+        assertThat(actualResult.getDocumentTags()).isNotNull();
+        assertThat(actualResult.getDocumentTags().size()).isEqualTo(2);
+        assertThat(actualResult.getDocumentTags().get(0)).isEqualTo("ORIGINAL");
+        assertThat(actualResult.getDocumentTags().get(1)).isEqualTo("DRAFT");
         verify(restHelper).get(documentService, url, GetDocumentsResponse.class);
         verifyNoMoreInteractions(restHelper);
     }


### PR DESCRIPTION
Enrich endpoint that retrieves list of documents for a case with additional list of document tags for the case type.