### PR TITLE
Updating local retry config

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -4,4 +4,8 @@ notify.redrive.policy={"maxReceiveCount": "${notify.queue.maximumRedeliveries}",
 notify.queue=aws-sqs://${notify.queue.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All&redrivePolicy=${notify.redrive.policy}&waitTimeSeconds=20
 notify.queue.dlq=aws-sqs://${notify.queue.dlq.name}?amazonSQSClient=#notifySqsClient&messageAttributeNames=All
 
+# speeds things up a lot when you don't have all services running locally
+retry.maxAttempts=2
+retry.delay=1000
+
 


### PR DESCRIPTION
This should reduce the number of redundant calls this service
makes when we don't have docs or audit running locally.
This significantly improves the response time on local env.