### PR TITLE
HOCS-1910 - CurrentStage value should when a case is completed

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -317,7 +317,11 @@ public class CaseDataService {
         log.debug("Updating completed status Case: {} completed {}", caseUUID, completed);
         CaseData caseData = getCaseData(caseUUID);
         caseData.setCompleted(completed);
+        if(completed){
+            caseData.update(Map.of(CaseworkConstants.CURRENT_STAGE, ""), objectMapper );
+        }
         caseDataRepository.save(caseData);
+        auditClient.updateCaseAudit(caseData, null);
         auditClient.completeCaseAudit(caseData);
         log.info("Updated Case: {} completed {}", caseUUID, completed, value(EVENT, CASE_COMPLETED));
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseworkConstants.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseworkConstants.java
@@ -1,0 +1,6 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+public interface CaseworkConstants {
+
+    String CURRENT_STAGE = "CurrentStage";
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -317,7 +317,7 @@ public class StageService {
     }
 
     private void updateCurrentStageForCase(UUID caseUUID, UUID stageUUID, String stageType) {
-        caseDataService.updateCaseData(caseUUID, stageUUID, Map.of("CurrentStage", stageType));
+        caseDataService.updateCaseData(caseUUID, stageUUID, Map.of(CaseworkConstants.CURRENT_STAGE, stageType));
     }
 
     private void updatePriority(Collection<Stage> stages) {
@@ -341,6 +341,7 @@ public class StageService {
         Map<String, String> data = new HashMap<>();
         data.put("Withdrawn", "True");
         data.put("WithdrawalDate", request.getWithdrawalDate());
+        data.put(CaseworkConstants.CURRENT_STAGE, "");
 
         caseDataService.updateCaseData(caseUUID, stageUUID, data);
         caseDataService.completeCase(caseUUID, true);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -684,6 +684,7 @@ public class StageServiceTest {
         Map<String, String> expectedData = new HashMap<>();
         expectedData.put("Withdrawn", "True");
         expectedData.put("WithdrawalDate", "2010-11-23");
+        expectedData.put("CurrentStage", "");
 
         verify(caseDataService).getCase(caseUUID);
         verify(caseDataService).updateCaseData(caseUUID, stageUUID, expectedData);


### PR DESCRIPTION
- blanking CurrentStage value when case is withdrawn
- blanking CurrentStage value when case is completed
- case updated audit had to be triggered on case completion for
the case_data extract to pick up field changes.