### PR TITLE
HOCS-2195: Correct indexes on somu item table

### DIFF
--- a/src/main/resources/db/migration/postgresql/V1_7__2195_Multiple_Contributions_Somu_Item_Correct_Index.sql
+++ b/src/main/resources/db/migration/postgresql/V1_7__2195_Multiple_Contributions_Somu_Item_Correct_Index.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_somu_item_uuid;
+DROP INDEX IF EXISTS idx_somu_item_case_uuid;
+
+CREATE INDEX IF NOT EXISTS idx_somu_item_uuid ON somu_item(uuid);


### PR DESCRIPTION
When creating the somu_item table an incorrect index was created 'idx_somu_item_uuid' that pointed to somu_item(case_uuid). This should have been pointing to somu_item(uuid).

There is also a redundant index in 'idx_somu_item_case_uuid' as a result of 'idx_somu_item_case_uuid_type'. This is because indexes work left to right in subsets. so this indexes case_uuid and case_uuid and type together.
