### PR TITLE
HOCS-2240 Add missing dollar sign

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ pipeline:
         # you aren't allowed slashes in Docker tags, so this replaces them with underscores
         # there is a nicer way to do this in Drone 1.0, but for 0.8 we need to hack with sed:
       - export BRANCH_NAME_TAGFRIENDLY=`echo "$${DRONE_COMMIT_BRANCH}" | sed 's$/$_$g'` # sed can use any character as delimiter
-      - docker tag hocs-casework quay.io/ukhomeofficedigital/hocs-casework:branch-${BRANCH_NAME_TAGFRIENDLY}
+      - docker tag hocs-casework quay.io/ukhomeofficedigital/hocs-casework:branch-$${BRANCH_NAME_TAGFRIENDLY}
       - docker push quay.io/ukhomeofficedigital/hocs-casework:build-$${DRONE_BUILD_NUMBER}
     when:
       branch: [master, epic/*] # this should be any branch you might reasonably want deployed somewhere


### PR DESCRIPTION
Drone requires that interpolated variables have a double dollar sign.
I'm not sure why.