### PR TITLE
HOCS-2235: change somu item to upsert on no retrieval

### DIFF
--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetSomuItemResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetSomuItemResponseTest.java
@@ -15,7 +15,7 @@ public class GetSomuItemResponseTest {
     
     @Test
     public void getSomuItemResponseTest() {
-        SomuItem somuItem = new SomuItem(SOMU_ITEM_UUID, SOMU_ITEM_CASE_UUID, SOMU_ITEM_TYPE_UUID, "");
+        SomuItem somuItem = new SomuItem(SOMU_ITEM_UUID, SOMU_ITEM_CASE_UUID, SOMU_ITEM_TYPE_UUID, "TEST");
         
         GetSomuItemResponse getSomuItemResponse = GetSomuItemResponse.from(somuItem);
 
@@ -27,7 +27,7 @@ public class GetSomuItemResponseTest {
     }
 
     @Test
-    public void getSomuItemResponseTest_NullDataIsDeleted() {
+    public void getSomuItemResponseTest_NullIsDeleted() {
         SomuItem somuItem = new SomuItem(SOMU_ITEM_UUID, SOMU_ITEM_CASE_UUID, SOMU_ITEM_TYPE_UUID, null);
 
         GetSomuItemResponse getSomuItemResponse = GetSomuItemResponse.from(somuItem);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/SomuItemTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/SomuItemTest.java
@@ -14,12 +14,12 @@ public class SomuItemTest {
 
     @Test
     public void getSomuItem() {
-        SomuItem somuItem = new SomuItem(SOMU_ITEM_UUID, SOMU_ITEM_CASE_UUID, SOMU_ITEM_TYPE_UUID, "");
+        SomuItem somuItem = new SomuItem(SOMU_ITEM_UUID, SOMU_ITEM_CASE_UUID, SOMU_ITEM_TYPE_UUID, "Test");
 
         assertThat(somuItem.getUuid()).isEqualTo(SOMU_ITEM_UUID);
         assertThat(somuItem.getCaseUuid()).isEqualTo(SOMU_ITEM_CASE_UUID);
         assertThat(somuItem.getSomuUuid()).isEqualTo(SOMU_ITEM_TYPE_UUID);
-        assertThat(somuItem.getData()).isEqualTo("");
+        assertThat(somuItem.getData()).isEqualTo("Test");
         assertThat(somuItem.isDeleted()).isFalse();
     }
     


### PR DESCRIPTION
At present when we try and get a somu item, if the item is not found then we currently throw an entity is not found exception. Whereas the new functionality means that a dummy somu item is created (that's classed as deleted) that will allow for the frontend to add and populate data based on the somu item uuid.