### PR TITLE
HOCS-2236: upsert somu item improvements

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResource.java
@@ -50,8 +50,8 @@ public class SomuItemResource {
 
     @Authorised(accessLevel = AccessLevel.WRITE)
     @PostMapping(value = "/case/{caseUuid}/item/{somuTypeUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
-    ResponseEntity<GetSomuItemResponse> upsertSomuItem(@PathVariable UUID caseUuid, @PathVariable UUID somuTypeUuid, @RequestBody String data) {
-        SomuItem somuItem = somuItemService.upsertSomuItem(caseUuid, somuTypeUuid, data);
+    ResponseEntity<GetSomuItemResponse> upsertSomuItem(@PathVariable UUID caseUuid, @PathVariable UUID somuTypeUuid, @RequestBody CreateSomuItemRequest data) {
+        SomuItem somuItem = somuItemService.upsertSomuItem(caseUuid, somuTypeUuid, data.getData());
         return ResponseEntity.ok(GetSomuItemResponse.from(somuItem));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateSomuItemRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateSomuItemRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateSomuItemRequest {
+    
+    @JsonProperty("data")
+    private final String data;
+    
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResourceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.casework.api.dto.CreateSomuItemRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.GetSomuItemResponse;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.SomuItem;
@@ -42,7 +43,7 @@ public class SomuItemResourceTest {
         
         when(somuItemService.upsertSomuItem(caseUUID, somuUUID, "{}")).thenReturn(somuItem);
 
-        ResponseEntity<GetSomuItemResponse> response = somuItemResource.upsertSomuItem(caseUUID, somuUUID, "{}");
+        ResponseEntity<GetSomuItemResponse> response = somuItemResource.upsertSomuItem(caseUUID, somuUUID, new CreateSomuItemRequest("{}"));
 
         verify(somuItemService, times(1)).upsertSomuItem(caseUUID, somuUUID, "{}");
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateSomuItemRequestTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateSomuItemRequestTest.java
@@ -1,0 +1,16 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CreateSomuItemRequestTest {
+    
+    @Test
+    public void createCreatSomuItemRequest() {
+        String data = "DATA";
+        CreateSomuItemRequest CreateSomuItemRequest = new CreateSomuItemRequest(data);
+        assertThat(CreateSomuItemRequest.getData()).isEqualTo(data);
+    }
+    
+}


### PR DESCRIPTION
Change the upsert of a somu item to expect CreateSomuItemRequest object (which is just a data json string). This allows us to get past the funky encoding that the frontend does with form encoding if we send a string as the body.