### PR TITLE
HOCS-2254-Allow multiple value fields for each check field

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/EntityTotalDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/EntityTotalDto.java
@@ -1,9 +1,11 @@
 package uk.gov.digital.ho.hocs.casework.client.infoclient;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -11,8 +13,10 @@ import java.util.Map;
 public class EntityTotalDto {
 
     @JsonProperty("addFields")
-    private Map<String, String> addFields;
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private Map<String, List<String>> addFields;
 
     @JsonProperty("subFields")
-    private Map<String, String> subFields;
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private Map<String, List<String>> subFields;
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/DataTotalTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/DataTotalTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,10 +47,10 @@ public class DataTotalTest {
         dataMap.put("CcCheck", "");
         dataMap.put("CcValue", "3.03");
         DataTotal dataTotal = new DataTotal();
-        Map<String, String> addFields = new HashMap();
-        addFields.put(null, "AaValue");
-        addFields.put("", "BbValue");
-        addFields.put(" ", "CcValue");
+        Map<String, List<String>> addFields = new HashMap();
+        addFields.put(null, List.of("AaValue"));
+        addFields.put("", List.of("BbValue"));
+        addFields.put(" ", List.of("CcValue"));
 
         BigDecimal result = dataTotal.calculate(dataMap, addFields, makeSubFields());
 
@@ -64,14 +65,15 @@ public class DataTotalTest {
         dataMap.put("BbCheck", "Yes");
         dataMap.put("BbValue", "2.02");
         dataMap.put("CcCheck", "Yes");
-        dataMap.put("CcValue", "3.03");
+        dataMap.put("CcValue1", "3.03");
+        dataMap.put("CcValue2", "1.00");
         dataMap.put("DdCheck", "");
         dataMap.put("DdMinus", "4.04");
         DataTotal dataTotal = new DataTotal();
 
         BigDecimal result = dataTotal.calculate(dataMap, makeAddFields(), makeSubFields());
 
-        assertThat(result).isEqualTo(new BigDecimal("6.06"));
+        assertThat(result).isEqualTo(new BigDecimal("7.06"));
     }
 
     @Test
@@ -82,28 +84,32 @@ public class DataTotalTest {
         dataMap.put("BbCheck", "Yes");
         dataMap.put("BbValue", "2.02");
         dataMap.put("CcCheck", "Yes");
-        dataMap.put("CcValue", "3.03");
+        dataMap.put("CcValue1", "3.03");
+        dataMap.put("CcValue2", "1.00");
         dataMap.put("DdCheck", "Yes");
         dataMap.put("DdMinus", "4.04");
+        dataMap.put("EeCheck", "Yes");
+        dataMap.put("EeMinus1", "1.00");
+        dataMap.put("EeMinus2", "0.01");
         DataTotal dataTotal = new DataTotal();
 
         BigDecimal result = dataTotal.calculate(dataMap, makeAddFields(), makeSubFields());
 
-        assertThat(result).isEqualTo(new BigDecimal("2.02"));
+        assertThat(result).isEqualTo(new BigDecimal("2.01"));
     }
 
-    private Map<String, String> makeAddFields(){
-        Map<String, String> addFields = new HashMap();
-        addFields.put("AaCheck", "AaValue");
-        addFields.put("BbCheck", "BbValue");
-        addFields.put("CcCheck", "CcValue");
+    private Map<String, List<String>> makeAddFields(){
+        Map<String, List<String>> addFields = new HashMap();
+        addFields.put("AaCheck", List.of("AaValue"));
+        addFields.put("BbCheck", List.of("BbValue"));
+        addFields.put("CcCheck", List.of("CcValue1", "CcValue2"));
         return addFields;
     }
 
-    private Map<String, String> makeSubFields(){
-        Map<String, String> subFields = new HashMap();
-        subFields.put("DdCheck", "DdMinus");
-        subFields.put("EeCheck", "EeMinus");
+    private Map<String, List<String>> makeSubFields(){
+        Map<String, List<String>> subFields = new HashMap();
+        subFields.put("DdCheck", List.of("DdMinus"));
+        subFields.put("EeCheck", List.of("EeMinus1", "EeMinus2"));
         return subFields;
     }
 }


### PR DESCRIPTION
HOCS-2254 adds additional uplift amounts.

These values need to be totalled up in Total Awarded and Total Paid.

Currently these totals are made of lists of fields to add and fields to subtract. Each field has a corresponding "check field", the value of which is used to determine whether to include the field in the total. As this check field is also used as the key to the map of fields to add, it is currently impossible to add two value fields with the same check field.

This change allows an array to be passed with each check field, whilst still accepting single values. I chose this solution as it allows existing projects to remain unaffected.