### PR TITLE
HOCS-2199: Change to audit payloads

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -247,7 +247,7 @@ public class AuditClient {
         executorService.execute(() -> {
             String data = "{}";
             try {
-                data = objectMapper.writeValueAsString(somuTypeUUID);
+                data = objectMapper.writeValueAsString(new AuditPayload.SomuItem(somuTypeUUID));
             } catch (JsonProcessingException e) {
                 logFailedToParseDataPayload(e);
             }
@@ -263,7 +263,7 @@ public class AuditClient {
         executorService.execute(() -> {
             String data = "{}";
             try {
-                data = objectMapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+                data = objectMapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
             } catch (JsonProcessingException e) {
                 logFailedToParseDataPayload(e);
             }
@@ -278,7 +278,7 @@ public class AuditClient {
         executorService.execute(() -> {
             String data = "{}";
             try {
-                data = objectMapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+                data = objectMapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
             } catch (JsonProcessingException e) {
                 logFailedToParseDataPayload(e);
             }
@@ -293,7 +293,7 @@ public class AuditClient {
         executorService.execute(() -> {
             String data = "{}";
             try {
-                data = objectMapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+                data = objectMapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
             } catch (JsonProcessingException e) {
                 logFailedToParseDataPayload(e);
             }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
@@ -71,17 +71,23 @@ public interface AuditPayload {
     @AllArgsConstructor
     @Getter
     class SomuItem {
-        @JsonProperty("uuid")
-        private UUID uuid;
-
-        @JsonProperty("caseUuid")
-        private UUID caseUuid;
-
         @JsonProperty("somuUuid")
         private UUID somuUuid;
+    }
+
+    @Getter
+    class SomuItemWithData extends SomuItem {
+        @JsonProperty("uuid")
+        private UUID uuid;
         
         @JsonRawValue
         private String data;
+
+        public SomuItemWithData(UUID somuUuid, UUID uuid, String data) {
+            super(somuUuid);
+            this.uuid = uuid;
+            this.data = data;
+        }
     }
 
     @AllArgsConstructor

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClientTest.java
@@ -435,12 +435,15 @@ public class AuditClientTest {
         UUID somuUuid = UUID.randomUUID();
         SomuItem somuItem = new SomuItem(uuid, this.caseUUID, somuUuid, "{}");
 
+        String itemView = mapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid()));
+
         auditClient.viewCaseSomuItemsBySomuTypeAudit(caseUUID, uuid);
         verify(producerTemplate).sendBodyAndHeaders(eq(auditQueue), jsonCaptor.capture(), any());
 
         CreateAuditRequest request = mapper.readValue((String)jsonCaptor.getValue(), CreateAuditRequest.class);
         assertThat(request.getType()).isEqualTo(EventType.SOMU_ITEM_VIEWED);
         assertThat(request.getCaseUUID()).isEqualTo(somuItem.getCaseUuid());
+        assertThat(request.getAuditPayload()).isEqualTo(itemView);
     }
 
     @Test
@@ -449,7 +452,7 @@ public class AuditClientTest {
         UUID somuUuid = UUID.randomUUID();
         SomuItem somuItem = new SomuItem(uuid, this.caseUUID, somuUuid, "{}");
 
-        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
         
         auditClient.createCaseSomuItemAudit(somuItem);
         verify(producerTemplate).sendBodyAndHeaders(eq(auditQueue), jsonCaptor.capture(), any());
@@ -466,7 +469,7 @@ public class AuditClientTest {
         UUID somuUuid = UUID.randomUUID();
         SomuItem somuItem = new SomuItem(uuid, this.caseUUID, somuUuid, "{}");
         
-        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
 
         auditClient.updateSomuItemAudit(somuItem);
         verify(producerTemplate).sendBodyAndHeaders(eq(auditQueue), jsonCaptor.capture(), any());
@@ -483,7 +486,7 @@ public class AuditClientTest {
         UUID somuUuid = UUID.randomUUID();
         SomuItem somuItem = new SomuItem(uuid, this.caseUUID, somuUuid, "{}");
 
-        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItem(somuItem.getUuid(), somuItem.getCaseUuid(), somuItem.getSomuUuid(), somuItem.getData()));
+        String itemUpdate = mapper.writeValueAsString(new AuditPayload.SomuItemWithData(somuItem.getUuid(), somuItem.getSomuUuid(), somuItem.getData()));
 
         auditClient.deleteSomuItemAudit(somuItem);
         verify(producerTemplate).sendBodyAndHeaders(eq(auditQueue), jsonCaptor.capture(), any());


### PR DESCRIPTION
At present we are currently trying to map a string to JSON, which results in invalid JSON being received by the audit service. This change encompasses this by having a basic SomuItem class that contains just the SomuTypeUUID for the View. This class is inherited when we do a update, add or delete of an SomuItem to allow for further information being passed.