### PR TITLE
HOCS-2555 - New endpoint to return active stage for a given case.

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -155,6 +155,12 @@ class StageResource {
         return ResponseEntity.ok(GetStagesResponse.from(stages));
     }
 
+    @GetMapping(value = "/active-stage/case/{caseUUID}")
+    ResponseEntity<GetStagesResponse> getActiveStagesByCase(@PathVariable UUID caseUUID) {
+        Set<Stage> stages = stageService.getActiveStagesByCaseUUID(caseUUID);
+        return ResponseEntity.ok(GetStagesResponse.from(stages));
+    }
+
     @Allocated(allocatedTo = AllocationLevel.USER_OR_TEAM)
     @PostMapping(value = "/case/{caseUUID}/stage/{stageUUID}/withdraw")
     ResponseEntity withdrawCase(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID, @RequestBody WithdrawCaseRequest request) {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -148,7 +148,7 @@ public class StageResourceTest {
 
         when(stageService.getActiveStagesByCaseUUID(caseUUID)).thenReturn(stages);
 
-        ResponseEntity<GetStagesResponse> response =  stageResource.getActiveStagesByCase(caseUUID);
+        ResponseEntity<GetStagesResponse> response = stageResource.getActiveStagesByCase(caseUUID);
 
         verify(stageService).getActiveStagesByCaseUUID(caseUUID);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -142,6 +142,23 @@ public class StageResourceTest {
     }
 
     @Test
+    public void shouldGetActiveStagesCaseUUID() {
+        Set<Stage> stages = new HashSet<>();
+        UUID caseUUID = UUID.randomUUID();
+
+        when(stageService.getActiveStagesByCaseUUID(caseUUID)).thenReturn(stages);
+
+        ResponseEntity<GetStagesResponse> response =  stageResource.getActiveStagesByCase(caseUUID);
+
+        verify(stageService).getActiveStagesByCaseUUID(caseUUID);
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
     public void shouldGetActiveStages() {
 
         Set<Stage> stages = new HashSet<>();


### PR DESCRIPTION
The case-creator service needs a way to find out the current active stage for a case.
This endpoint was added to allow that query.

It does return a Set but I believe that there can only be one active stage for a case. (I think the Set is a JPA limitation)

The client side code checks the Set length and if there is more than one it will raise an exception.
