### PR TITLE
HOCS-2680: push through `poTeamUuid`

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/SearchRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/SearchRequest.java
@@ -48,6 +48,9 @@ public class SearchRequest {
     @JsonProperty("topic")
     private String topic;
 
+    @JsonProperty("poTeamUuid")
+    private String poTeamUuid;
+
     @JsonProperty("data")
     private Map<String, String> data;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/searchclient/SearchClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/searchclient/SearchClient.java
@@ -23,9 +23,9 @@ public class SearchClient {
 
     @Autowired
     public SearchClient(RestHelper restHelper,
-                        @Value("${hocs.search-service}") String infoService) {
+                        @Value("${hocs.search-service}") String searchService) {
         this.restHelper = restHelper;
-        this.serviceBaseURL = infoService;
+        this.serviceBaseURL = searchService;
     }
 
     public Set<UUID> search(SearchRequest searchRequest) {


### PR DESCRIPTION
The frontend calls to this service and then casework requests to search, 
therefore to allow for search to use the value it needs to be passed
through