### PR TITLE
HOCS-2457 add Spring config to allow Swagger service on casework

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,3 @@
+/main/
+/test/
+/default/

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
     implementation('net.logstash.logback:logstash-logback-encoder:5.3')
     implementation('uk.gov.service.notify:notifications-java-client:3.12.0-RELEASE')
 
+    implementation('io.springfox:springfox-swagger2:2.9.2')
+    implementation('io.springfox:springfox-swagger-ui:2.9.2')
+
     runtimeOnly('org.postgresql:postgresql')
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.6'

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/application/SpringConfiguration.java
@@ -9,9 +9,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import java.text.SimpleDateFormat;
 
+@EnableSwagger2
 @Configuration
 public class SpringConfiguration implements WebMvcConfigurer {
 
@@ -35,6 +41,16 @@ public class SpringConfiguration implements WebMvcConfigurer {
         m.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         m.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         return m;
+    }
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(new ApiInfo("DECS Casework API","Casework Endpoints", "", "", "","",""))
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/application/SpringConfiguration.java
@@ -9,12 +9,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
 import java.text.SimpleDateFormat;
 
 @EnableSwagger2
@@ -41,16 +37,6 @@ public class SpringConfiguration implements WebMvcConfigurer {
         m.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         m.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         return m;
-    }
-
-    @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .apiInfo(new ApiInfo("DECS Casework API","Casework Endpoints", "", "", "","",""))
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.any())
-                .build();
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/application/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/application/SwaggerConfiguration.java
@@ -1,0 +1,32 @@
+package uk.gov.digital.ho.hocs.casework.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@Slf4j
+@EnableSwagger2
+@Profile({"swagger"})
+public class SwaggerConfiguration implements WebMvcConfigurer {
+
+    @Bean
+    public Docket api() {
+        log.info("Swagger enabled in Casework Application...");
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(new ApiInfo("DECS Casework API","Casework Endpoints", "", "", "","",""))
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+}


### PR DESCRIPTION
This ticket adds a Swagger service to casework giving us access to all the exposed api endpoints published by the casework service.
The Swagger page is available at http://localhost:8082/swagger-ui.html