### PR TITLE
HOCS-2769 Deploy to hocs-delta automatically

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -137,6 +137,25 @@ steps:
     depends_on:
       - clone kube repo
 
+  - name: deploy to delta
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-casework
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: hocs-delta
+      KUBE_TOKEN:
+        from_secret: hocs_casework_hocs_delta
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: build_${DRONE_BUILD_NUMBER}
+    when:
+      branch:
+        - epic/HOCS-COMP
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
   - name: wait for docker
     image: docker
     commands:


### PR DESCRIPTION
This adds a step to Drone that fires on push to the COMP epic branch,
which triggers a deployment to the hocs-delta environment.

Previously we were deploying manually to hocs-delta, and using a fixed
branch-based tag, which was causing inconsistencies and confusion. Here
we deploy a tag based on the Drone build number, which is easier to
track. If we wanted, we could deploy using the SHA hash for a similar
effect.