### PR TITLE
HOCS-2975: change endpoint protection

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -75,7 +75,7 @@ class CaseDataResource {
         return ResponseEntity.ok(totals);
     }
 
-    @Allocated(allocatedTo = AllocationLevel.USER)
+    @Authorised(accessLevel = AccessLevel.WRITE)
     @PutMapping(value = "/case/{caseUUID}/stage/{stageUUID}/data")
     ResponseEntity updateCaseData(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID, @RequestBody UpdateCaseDataRequest request) {
         caseDataService.updateCaseData(caseUUID, stageUUID, request.getData());


### PR DESCRIPTION
Currently if we want to update case data, the case has to be 
allocated to the user. As we now allow for WCS cases to be moved 
without allocation. This needs to be changed to accommodate the 
CaseworkTeamUUID data update. To still have some protection, this 
change makes it so the user has to be part of a team that allows 
WRITE permissions.