### PR TITLE
HOCS-3299: Add endpoint for active stage by Case UUID

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -211,6 +211,20 @@ public class StageService {
         return stageRepository.findAllActiveByCaseUUID(caseUUID);
     }
 
+    Optional<Stage> getActiveStageByCaseUUID(UUID caseUUID){
+        log.debug("Getting Active Stage for Case: {}", caseUUID);
+        Set<Stage> stages = stageRepository.findAllActiveByCaseUUID(caseUUID);
+        switch (stages.size()){
+            case 0:
+                return Optional.empty();
+            case 1:
+                return Optional.of(stages.iterator().next());
+            default:
+                throw new IllegalStateException(String.format("Multiple Active Stages returned for case: %s",
+                    caseUUID.toString()));
+        }
+    }
+
     Set<Stage> getActiveStagesByTeamUUID(UUID teamUUID) {
         log.debug("Getting Active Stages for Team: {}", teamUUID);
         Set<Stage> stages = stageRepository.findAllActiveByTeamUUID(teamUUID);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -13,10 +13,7 @@ import uk.gov.digital.ho.hocs.casework.client.infoclient.UserDto;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -198,7 +195,7 @@ public class StageResourceTest {
     public void shouldGetActiveStageCaseUuid() throws UnsupportedEncodingException {
         UUID caseUuid = UUID.randomUUID();
 
-        Stage stage = new Stage();
+        Optional<Stage> stage = Optional.of(new Stage());
 
         when(stageService.getActiveStageByCaseUUID(caseUuid)).thenReturn(stage);
 
@@ -216,7 +213,7 @@ public class StageResourceTest {
     public void shouldGetActiveStageCaseUuid_NotFound() throws UnsupportedEncodingException {
         UUID caseUuid = UUID.randomUUID();
 
-        when(stageService.getActiveStageByCaseUUID(caseUuid)).thenReturn(null);
+        when(stageService.getActiveStageByCaseUUID(caseUuid)).thenReturn(Optional.empty());
 
         ResponseEntity<Stage> response = stageResource.getActiveStageForCaseByCaseUuid(caseUuid.toString());
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -181,6 +181,7 @@ public class StageResourceTest {
 
         Set<Stage> stages = new HashSet<>();
 
+
         when(stageService.getActiveStagesByCaseReference(ref)).thenReturn(stages);
 
         ResponseEntity<GetStagesResponse> response = stageResource.getActiveStagesForCase(ref);
@@ -191,6 +192,40 @@ public class StageResourceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldGetActiveStageCaseUuid() throws UnsupportedEncodingException {
+        UUID caseUuid = UUID.randomUUID();
+
+        Stage stage = new Stage();
+
+        when(stageService.getActiveStageByCaseUUID(caseUuid)).thenReturn(stage);
+
+        ResponseEntity<Stage> response = stageResource.getActiveStageForCaseByCaseUuid(caseUuid.toString());
+
+        verify(stageService).getActiveStageByCaseUUID(caseUuid);
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldGetActiveStageCaseUuid_NotFound() throws UnsupportedEncodingException {
+        UUID caseUuid = UUID.randomUUID();
+
+        when(stageService.getActiveStageByCaseUUID(caseUuid)).thenReturn(null);
+
+        ResponseEntity<Stage> response = stageResource.getActiveStageForCaseByCaseUuid(caseUuid.toString());
+
+        verify(stageService).getActiveStageByCaseUUID(caseUuid);
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_ALLOCATED_TO_USER;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StageServiceTest {
+public class  StageServiceTest {
 
     private final UUID caseUUID = UUID.randomUUID();
     private final UUID teamUUID = UUID.randomUUID();
@@ -288,6 +288,17 @@ public class StageServiceTest {
     public void shouldGetActiveStagesCaseUUID() {
 
         stageService.getActiveStagesByCaseUUID(caseUUID);
+
+        verify(stageRepository).findAllActiveByCaseUUID(caseUUID);
+
+        verifyNoMoreInteractions(stageRepository);
+        verifyZeroInteractions(notifyClient);
+
+    }
+
+    @Test
+    public void shouldGetActiveStageCaseUUID() {
+        stageService.getActiveStageByCaseUUID(caseUUID);
 
         verify(stageRepository).findAllActiveByCaseUUID(caseUUID);
 
@@ -711,7 +722,7 @@ public class StageServiceTest {
         verifyNoMoreInteractions(stageRepository);
         verifyZeroInteractions(notifyClient);
     }
-    
+
     /**
      * The stage cannot be an instance as it does not have a function to set data (in the Stage Class).
      * I did not want to create a setData on the Stage class for testing only.


### PR DESCRIPTION
- Added a new endpoint the allows you to get the active stage for a case by it's UUID.
- Added a new method in StageService that ensures only one stage is returned.