### PR TITLE
HOCS-3421: increase hikari connection pool size

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ server.compression.enabled=true
 server.compression.mime-types=application/json;charset=UTF-8, application/json
 
 spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:casework}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
+spring.datasource.hikari.maximumPoolSize=20
 spring.flyway.locations=classpath:/db/migration/postgresql
 spring.flyway.schemas=${db.schema.name:casework}
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false


### PR DESCRIPTION
During a Live Service incident we saw that there was occurences
whereby the default connection pool size of 10 were all being used
up. This was causing the pods to crash and fail the health check.
To remediate from this, the default connection pool size has been
increased to 20 while we investigate what the correct number for
the system should be.