### PR TITLE
Simplify Drone Pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
     depends_on:
       - build project
 
-  - name: build & push
+  - name: build & push branch
     image: plugins/docker
     settings:
       registry: quay.io
@@ -46,15 +46,21 @@ steps:
       DOCKER_PASSWORD:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    when:
+      branch:
+        exclude:
+          - main
     depends_on:
       - test project
 
-  - name: build & push latest
+  - name: build & push main
     image: plugins/docker
     settings:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-casework
       tags:
+        - build_${DRONE_BUILD_NUMBER}
+        - ${DRONE_COMMIT_SHA}
         - latest
     environment:
       DOCKER_PASSWORD:


### PR DESCRIPTION
It appears that one of the two `build and push` commands that we have
routinely fails. To try and simplify this and remove this edge case, we
now only run one on a push to branches and one on push to main.