### PR TITLE
HOCS-3645: add correspondent type display name

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CorrespondentTypeDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CorrespondentTypeDto.java
@@ -1,10 +1,14 @@
 package uk.gov.digital.ho.hocs.casework.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class CorrespondentTypeDto {
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponse.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 @Getter
 public class GetCorrespondentWithPrimaryFlagResponse {
 
-
     @JsonProperty("uuid")
     private UUID uuid;
 
@@ -22,6 +21,9 @@ public class GetCorrespondentWithPrimaryFlagResponse {
 
     @JsonProperty("type")
     private String type;
+
+    @JsonProperty("typeDisplayName")
+    private String typeDisplayName;
 
     @JsonProperty("caseUUID")
     private UUID caseUUID;
@@ -52,6 +54,7 @@ public class GetCorrespondentWithPrimaryFlagResponse {
                 correspondent.getUuid(),
                 correspondent.getCreated(),
                 correspondent.getCorrespondentType(),
+                correspondent.getCorrespondentTypeName(),
                 correspondent.getCaseUUID(),
                 correspondent.getFullName(),
                 AddressDto.from(correspondent),

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecorator.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecorator.java
@@ -1,0 +1,41 @@
+package uk.gov.digital.ho.hocs.casework.api.utils;
+
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.casework.api.dto.CorrespondentTypeDto;
+import uk.gov.digital.ho.hocs.casework.domain.model.BaseCorrespondent;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+public class CorrespondentTypeNameDecorator {
+
+    public <T extends BaseCorrespondent> Set<T> addCorrespondentTypeName(Set<CorrespondentTypeDto> correspondentTypes,
+                                                                         Set<T> correspondents) {
+        if (correspondentTypes == null) {
+            return correspondents;
+        }
+
+        correspondents.forEach(correspondent -> addCorrespondentTypeName(correspondentTypes, correspondent));
+
+        return correspondents;
+    }
+
+    public <T extends BaseCorrespondent> T addCorrespondentTypeName(Set<CorrespondentTypeDto> correspondentTypes,
+                                                                    T correspondent) {
+        if (correspondentTypes == null) {
+            return correspondent;
+        }
+
+        Optional<CorrespondentTypeDto> correspondentType = correspondentTypes.stream()
+                .filter(correspondentTypeDto -> Objects.equals(correspondentTypeDto.getType(), correspondent.getCorrespondentType()))
+                .findFirst();
+
+        correspondentType
+                .ifPresent(correspondentTypeDto -> correspondent.setCorrespondentTypeName(correspondentTypeDto.getDisplayName()));
+
+        return correspondent;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
@@ -48,6 +48,13 @@ public class InfoClient {
         return caseDataType;
     }
 
+    @Cacheable(value = "InfoClientGetCorrespondentType", unless = "#result == null")
+    public GetCorrespondentTypeResponse getAllCorrespondentType() {
+        GetCorrespondentTypeResponse correspondentType = restHelper.get(serviceBaseURL, "/correspondentType", GetCorrespondentTypeResponse.class);
+        log.info("Got CorrespondentTypes {}", correspondentType.getCorrespondentTypes().size(), value(EVENT, INFO_CLIENT_GET_CASE_TYPE_SUCCESS));
+        return correspondentType;
+    }
+
     @Cacheable(value = "InfoClientGetCorrespondentType", unless = "#result == null", key = "#caseType")
     public GetCorrespondentTypeResponse getCorrespondentType(String caseType) {
         GetCorrespondentTypeResponse correspondentType = restHelper.get(serviceBaseURL, String.format("/correspondentType/%s", caseType), GetCorrespondentTypeResponse.class);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @MappedSuperclass
-public class BaseCorrespondent implements Serializable {
+public abstract class BaseCorrespondent implements Serializable {
 
     @Id
     @Column(name = "id")
@@ -31,7 +31,7 @@ public class BaseCorrespondent implements Serializable {
 
     @Getter
     @Setter
-    @Column(name = "type_name")
+    @Transient
     protected String correspondentTypeName;
 
     @Getter

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
@@ -30,6 +30,11 @@ public class BaseCorrespondent implements Serializable {
     protected String correspondentType;
 
     @Getter
+    @Setter
+    @Column(name = "type_name")
+    protected String correspondentTypeName;
+
+    @Getter
     @Column(name = "case_uuid")
     protected UUID caseUUID;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Correspondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Correspondent.java
@@ -5,11 +5,12 @@ import lombok.NoArgsConstructor;
 import uk.gov.digital.ho.hocs.casework.application.LogEvent;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "correspondent")
 public class Correspondent extends BaseCorrespondent {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlag.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlag.java
@@ -6,16 +6,17 @@ import lombok.NoArgsConstructor;
 import uk.gov.digital.ho.hocs.casework.application.LogEvent;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "correspondent")
 public class CorrespondentWithPrimaryFlag extends BaseCorrespondent {
-
 
     @Getter
     @Column(name = "is_primary")

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/GetCorrespondentIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/GetCorrespondentIntegrationTest.java
@@ -16,14 +16,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCorrespondentTypeResponse;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.dto.GetAuditListResponse;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.PermissionDto;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.TeamDto;
-import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
 import uk.gov.digital.ho.hocs.casework.security.AccessLevel;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -77,6 +79,10 @@ public class GetCorrespondentIntegrationTest {
                 .expect(ExpectedCount.times(3), requestTo("http://localhost:8085/caseType/shortCode/a1"))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(mapper.writeValueAsString(CASE_DATA_TYPE), MediaType.APPLICATION_JSON));
+        mockInfoService
+                .expect(requestTo("http://localhost:8085/correspondentType/TEST"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(mapper.writeValueAsString(GetCorrespondentTypeResponse.from(Collections.emptySet())), MediaType.APPLICATION_JSON));
     }
 
     private MockRestServiceServer buildMockService(RestTemplate restTemplate) {
@@ -189,11 +195,14 @@ public class GetCorrespondentIntegrationTest {
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     }
 
-
-
     @Test
     public void shouldReturnOkWhenGetCorrespondentAndThenOkAndEmptySetWhenCorrespondentsDeleted() throws JsonProcessingException {
-        setupMockTeams("TEST",5, 4);
+        setupMockTeams("TEST", 5, 4);
+
+        mockInfoService
+                .expect(ExpectedCount.times(2), requestTo("http://localhost:8085/correspondentType/TEST"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(mapper.writeValueAsString(GetCorrespondentTypeResponse.from(Collections.emptySet())), MediaType.APPLICATION_JSON));
 
         ResponseEntity<String> result1 = testRestTemplate.exchange(
                 getBasePath() + "/case/" + CASE_UUID1 + "/correspondent/" + CORRESPONDENT_UUID, GET, new HttpEntity(createValidAuthHeaders()), String.class);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/GetCorrespondentsIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/GetCorrespondentsIntegrationTest.java
@@ -16,14 +16,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCorrespondentTypeResponse;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.dto.GetAuditListResponse;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.PermissionDto;
-import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.client.infoclient.TeamDto;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
 import uk.gov.digital.ho.hocs.casework.security.AccessLevel;
-import uk.gov.digital.ho.hocs.casework.client.infoclient.TeamDto;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -81,6 +83,10 @@ public class GetCorrespondentsIntegrationTest {
                 .expect(ExpectedCount.times(3), requestTo("http://localhost:8085/caseType/shortCode/a1"))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(mapper.writeValueAsString(CASE_DATA_TYPE), MediaType.APPLICATION_JSON));
+        mockInfoService
+                .expect(requestTo("http://localhost:8085/correspondentType/TEST"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(mapper.writeValueAsString(GetCorrespondentTypeResponse.from(Collections.emptySet())), MediaType.APPLICATION_JSON));
     }
 
     private MockRestServiceServer buildMockService(RestTemplate restTemplate) {
@@ -197,6 +203,12 @@ public class GetCorrespondentsIntegrationTest {
     @Test
     public void shouldReturnOkWhenGetCorrespondentAndThenOkAndEmptySetWhenCorrespondentsDeleted() throws JsonProcessingException {
         setupMockTeams("TEST", 5, 4);
+
+        mockInfoService
+                .expect(ExpectedCount.times(2), requestTo("http://localhost:8085/correspondentType/TEST"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(mapper.writeValueAsString(GetCorrespondentTypeResponse.from(Collections.emptySet())), MediaType.APPLICATION_JSON));
+
         ResponseEntity<String> result1 = testRestTemplate.exchange(
                 getBasePath() + "/case/" + CASE_UUID + "/correspondent", GET, new HttpEntity(createValidAuthHeaders()), String.class);
         assertThat(result1.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/UpdateCorrespondentIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/UpdateCorrespondentIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCorrespondentTypeResponse;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.PermissionDto;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.TeamDto;
 import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
@@ -24,12 +25,14 @@ import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository
 import uk.gov.digital.ho.hocs.casework.security.AccessLevel;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 import static org.springframework.test.web.client.MockRestServiceServer.bindTo;
@@ -80,6 +83,10 @@ public class UpdateCorrespondentIntegrationTest {
                 .expect(ExpectedCount.times(3), requestTo("http://localhost:8085/caseType/shortCode/a1"))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(mapper.writeValueAsString(CASE_DATA_TYPE), MediaType.APPLICATION_JSON));
+        mockInfoService
+                .expect(requestTo("http://localhost:8085/correspondentType/TEST"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(mapper.writeValueAsString(GetCorrespondentTypeResponse.from(Collections.emptySet())), MediaType.APPLICATION_JSON));
     }
 
     private MockRestServiceServer buildMockService(RestTemplate restTemplate) {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentTypeResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentTypeResponseTest.java
@@ -11,7 +11,6 @@ public class GetCorrespondentTypeResponseTest {
 
     @Test
     public void getGetCorrespondentTypeResponse() {
-
         CorrespondentTypeDto correspondentType = new CorrespondentTypeDto();
         Set<CorrespondentTypeDto> correspondentTypes = new HashSet<>();
         correspondentTypes.add(correspondentType);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentsResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentsResponseTest.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.hocs.casework.api.dto;
 
 import org.junit.Test;
 import uk.gov.digital.ho.hocs.casework.domain.model.Address;
-import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
 import uk.gov.digital.ho.hocs.casework.domain.model.CorrespondentWithPrimaryFlag;
 
 import java.util.HashSet;
@@ -13,48 +12,50 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GetCorrespondentsResponseTest {
 
+    private final CorrespondentWithPrimaryFlag correspondent = new CorrespondentWithPrimaryFlag(
+            UUID.randomUUID(),
+            "CORRESPONDENT",
+            "anyFullName",
+            new Address("anyPostcode", "any1", "any2", "any3", "anyCountry"),
+            "anyPhone",
+            "anyEmail",
+            "anyReference",
+            "external key",
+            true
+    );
+
     @Test
     public void getGetCorrespondentsResponse() {
-
-        UUID caseUUID = UUID.randomUUID();
-        String type = "CORRESPONDENT";
-        String fullName = "anyFullName";
-        Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        String phone = "anyPhone";
-        String email = "anyEmail";
-        String reference = "anyReference";
-        String externalKey = "external key";
-        Boolean isPrimary = true;
-
-        CorrespondentWithPrimaryFlag correspondent = new CorrespondentWithPrimaryFlag(
-                caseUUID,
-                type,
-                fullName,
-                address,
-                phone,
-                email,
-                reference,
-                externalKey,
-                isPrimary
-        );
-
-        Set<CorrespondentWithPrimaryFlag> correspondents = new HashSet<>();
-        correspondents.add(correspondent);
+        Set<CorrespondentWithPrimaryFlag> correspondents = Set.of(correspondent);
 
         GetCorrespondentsResponse getCorrespondentsResponse = GetCorrespondentsResponse.from(correspondents);
 
         assertThat(getCorrespondentsResponse.getCorrespondents()).hasSize(1);
+    }
 
+    @Test
+    public void getGetCorrespondentsResponse_withDisplayName() {
+        CorrespondentWithPrimaryFlag correspondentVal = correspondent;
+        String displayName = "Super Awesome Name";
+
+        correspondentVal.setCorrespondentTypeName(displayName);
+
+        Set<CorrespondentWithPrimaryFlag> correspondents = Set.of(correspondentVal);
+
+        GetCorrespondentsResponse getCorrespondentsResponse = GetCorrespondentsResponse.from(correspondents);
+
+        assertThat(getCorrespondentsResponse.getCorrespondents()).hasSize(1);
+        //noinspection OptionalGetWithoutIsPresent
+        assertThat(getCorrespondentsResponse.getCorrespondents().stream().findFirst().get().getTypeDisplayName())
+                .isEqualTo(displayName);
     }
 
     @Test
     public void getGetCorrespondentsResponseEmpty() {
-
         Set<CorrespondentWithPrimaryFlag> correspondents = new HashSet<>();
 
         GetCorrespondentsResponse getCorrespondentsResponse = GetCorrespondentsResponse.from(correspondents);
 
         assertThat(getCorrespondentsResponse.getCorrespondents()).hasSize(0);
-
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecoratorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecoratorTest.java
@@ -1,0 +1,72 @@
+package uk.gov.digital.ho.hocs.casework.api.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.digital.ho.hocs.casework.api.dto.CorrespondentTypeDto;
+import uk.gov.digital.ho.hocs.casework.domain.model.Address;
+import uk.gov.digital.ho.hocs.casework.domain.model.BaseCorrespondent;
+import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
+
+import java.util.Set;
+import java.util.UUID;
+
+@ExtendWith(SpringExtension.class)
+public class CorrespondentTypeNameDecoratorTest {
+
+    private final CorrespondentTypeNameDecorator correspondentTypeNameDecorator = new CorrespondentTypeNameDecorator();
+    private final Address address = new Address("postcode", "line1", "line2", "line3", "country");
+    private Correspondent correspondent;
+
+    @Before
+    public void setup() {
+        correspondent = new Correspondent(
+                UUID.randomUUID(),
+                "Type",
+                "full name",
+                address,
+                "01923478393",
+                "email@test.com",
+                "ref",
+                "key");
+    }
+
+    @Test
+    public void addCorrespondentTypeName_nullCorrespondentType() {
+        Set<BaseCorrespondent> correspondents = Set.of(correspondent);
+
+        Assert.assertEquals(correspondentTypeNameDecorator.addCorrespondentTypeName(null, correspondents), correspondents);
+
+        Assert.assertEquals(correspondentTypeNameDecorator.addCorrespondentTypeName(null, correspondent), correspondent);
+    }
+
+    @Test
+    public void addCorrespondentTypeName_correspondentTypeNotPresent() {
+        Set<BaseCorrespondent> correspondents = Set.of(correspondent);
+        Set<CorrespondentTypeDto> correspondentTypeDtos = Set.of(new CorrespondentTypeDto(UUID.randomUUID(), "Test", "Test"));
+
+        Set<BaseCorrespondent> correspondentsAfter = correspondentTypeNameDecorator.addCorrespondentTypeName(correspondentTypeDtos, correspondents);
+        Assert.assertTrue(correspondentsAfter.contains(correspondent));
+
+        BaseCorrespondent correspondentAfter = correspondentTypeNameDecorator.addCorrespondentTypeName(correspondentTypeDtos, correspondent);
+        Assert.assertEquals(correspondentAfter, correspondent);
+    }
+
+    @Test
+    public void addCorrespondentTypeName_correspondentTypePresent() {
+        Set<BaseCorrespondent> correspondents = Set.of(correspondent);
+        Set<CorrespondentTypeDto> correspondentTypeDtos = Set.of(new CorrespondentTypeDto(UUID.randomUUID(), "This is a test.", "Type"));
+
+        correspondent.setCorrespondentTypeName("This is a test.");
+
+        Set<BaseCorrespondent> correspondentsAfterDecorated = correspondentTypeNameDecorator.addCorrespondentTypeName(correspondentTypeDtos, correspondents);
+        Assert.assertTrue(correspondentsAfterDecorated.contains(correspondent));
+
+        BaseCorrespondent correspondentAfterDecorated = correspondentTypeNameDecorator.addCorrespondentTypeName(correspondentTypeDtos, correspondent);
+        Assert.assertEquals(correspondentAfterDecorated, correspondent);
+    }
+
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClientTest.java
@@ -30,6 +30,22 @@ public class InfoClientTest {
     }
 
     @Test
+    public void getAllCorrespondentType() {
+        CorrespondentTypeDto correspondentTypeDto = new CorrespondentTypeDto();
+        GetCorrespondentTypeResponse getCorrespondentType = new GetCorrespondentTypeResponse(new HashSet<>(Arrays.asList(correspondentTypeDto)));
+        when(restHelper.get("infoService", "/correspondentType", GetCorrespondentTypeResponse.class)).thenReturn(getCorrespondentType);
+
+        GetCorrespondentTypeResponse getCorrespondentTypeResponse = infoClient.getAllCorrespondentType();
+
+        assertThat(getCorrespondentTypeResponse).isNotNull();
+        assertThat(getCorrespondentTypeResponse.getCorrespondentTypes()).isNotNull();
+        assertThat(getCorrespondentTypeResponse.getCorrespondentTypes().size()).isEqualTo(1);
+
+        verify(restHelper).get("infoService", "/correspondentType", GetCorrespondentTypeResponse.class);
+        verifyNoMoreInteractions(restHelper);
+    }
+
+    @Test
     public void getCorrespondentType() {
 
         CorrespondentTypeDto correspondentTypeDto = new CorrespondentTypeDto();


### PR DESCRIPTION
Add a decorator that will take a list of CorrespondentTypeDto and
Correspondents and populate the `typeDisplayName`field of the
Correspondent if the value is there.

This new decorator is then called within the CorrespondentService
when returning Correspondents.