### PR TITLE
HOC-3670: stage user endpoint

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.hocs.casework.api;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.casework.api.dto.*;
@@ -21,8 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 @Slf4j
 @RestController
@@ -127,6 +126,12 @@ class StageResource {
     @GetMapping(value = "/stage")
     ResponseEntity<GetStagesResponse> getActiveStages() {
         Set<Stage> activeStages = stageService.getActiveStagesForUser();
+        return ResponseEntity.ok(GetStagesResponse.from(activeStages));
+    }
+
+    @GetMapping(value = "/stage/user/{userUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<GetStagesResponse> getActiveStagesForUser(@PathVariable UUID userUuid) {
+        Set<Stage> activeStages = stageService.getUserStages(userUuid);
         return ResponseEntity.ok(GetStagesResponse.from(activeStages));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -125,13 +125,13 @@ class StageResource {
 
     @GetMapping(value = "/stage")
     ResponseEntity<GetStagesResponse> getActiveStages() {
-        Set<Stage> activeStages = stageService.getActiveStagesForUser();
+        Set<Stage> activeStages = stageService.getActiveStagesForUsersTeamsAndCaseType();
         return ResponseEntity.ok(GetStagesResponse.from(activeStages));
     }
 
     @GetMapping(value = "/stage/user/{userUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<GetStagesResponse> getActiveStagesForUser(@PathVariable UUID userUuid) {
-        Set<Stage> activeStages = stageService.getUserStages(userUuid);
+        Set<Stage> activeStages = stageService.getActiveUserStagesWithTeamsAndCaseType(userUuid);
         return ResponseEntity.ok(GetStagesResponse.from(activeStages));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -266,7 +266,7 @@ public class StageService {
         return nextAvailableStage;
     }
 
-    Set<Stage> getActiveStagesForUser() {
+    Set<Stage> getActiveStagesForUsersTeamsAndCaseType() {
         log.debug("Getting Active Stages for User");
         Set<UUID> teams = userPermissionsService.getUserTeams();
         if (teams.isEmpty()) {
@@ -287,7 +287,7 @@ public class StageService {
         return stages;
     }
 
-    Set<Stage> getUserStages(UUID userUuid) {
+    Set<Stage> getActiveUserStagesWithTeamsAndCaseType(UUID userUuid) {
         log.debug("Getting users active stage");
         Set<UUID> teams = userPermissionsService.getUserTeams();
         if (teams.isEmpty()) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -38,6 +38,9 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
     @Query(value = "SELECT * FROM active_stage_data sd WHERE sd.team_uuid IN ?1 OR sd.case_type IN ?2", nativeQuery = true)
     Set<Stage> findAllActiveByTeamUUIDAndCaseType(Set<UUID> teamUUID, Set<String> caseTypes);
 
+    @Query(value = "SELECT * FROM active_stage_data sd WHERE user_uuid = ?1 AND NOT data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) AND (sd.team_uuid IN ?2 OR sd.case_type IN ?3)", nativeQuery = true)
+    Set<Stage> findAllActiveByUserUuidAndTeamUuidAndCaseType(UUID userUuid, Set<UUID> teamUUID, Set<String> caseTypes);
+
     @Query(value = "SELECT * FROM active_stage_data", nativeQuery = true)
     Set<Stage> findAllActive();
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -163,11 +163,27 @@ public class StageResourceTest {
 
         Set<Stage> stages = new HashSet<>();
 
-        when(stageService.getActiveStagesForUser()).thenReturn(stages);
+        when(stageService.getActiveStagesForUsersTeamsAndCaseType()).thenReturn(stages);
 
         ResponseEntity<GetStagesResponse> response = stageResource.getActiveStages();
 
-        verify(stageService).getActiveStagesForUser();
+        verify(stageService).getActiveStagesForUsersTeamsAndCaseType();
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldGetActiveStagesForUser() {
+        Set<Stage> stages = new HashSet<>();
+
+        when(stageService.getActiveUserStagesWithTeamsAndCaseType(userUUID)).thenReturn(stages);
+
+        ResponseEntity<GetStagesResponse> response = stageResource.getActiveStagesForUser(userUUID);
+
+        verify(stageService).getActiveUserStagesWithTeamsAndCaseType(userUUID);
 
         checkNoMoreInteractions();
 


### PR DESCRIPTION
Add an endpoint that returns all the active stages that the user
should have access too. This endpoint calls a native query that first
gets the stages that the user is assigned too, and then cross-references
with the teams the user has access to. As we have access to the
case data at this stage, this change also filters on `Unworkable`.

On QAX when timing the current `\stage` endpoint vs this new one with 
50 users hitting the system at the same time, the response time by the
service was as follows:

`Class: uk.gov.digital.ho.hocs.casework.api.StageResource. Method: getActiveStages. Execution time: 9405ms`
`Class: uk.gov.digital.ho.hocs.casework.api.StageResource. Method: getActiveStagesForUser. Execution time: 88ms`