### PR TITLE
HOCS-3787: Change failed response handling for CSVCaseDataUpdater

### DIFF
--- a/scripts/CsvCaseDataUpdater.java
+++ b/scripts/CsvCaseDataUpdater.java
@@ -218,7 +218,7 @@ public class CsvCaseDataUpdater {
 
                     // Report if the service does not return a 200 code
                     if (response.statusCode() != 200) {
-                        throw new RuntimeException("Failed to update case "
+                        LOGGER.log(Level.SEVERE, "FAILED: "
                                 + caseData.uuid
                                 + " with url: "
                                 + request.uri());


### PR DESCRIPTION
Currently, when we get a non-200 code from a request the rest of the
urls don't get requested. This can lead to partial updates which aren't
ideal. This change logs out a severe error when this occurs instead of
terminating the program.