### PR TITLE
HOCS-3831: Fix missing Stage 2 Case Data

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
@@ -13,6 +13,7 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 public class CopyCompToComp2 extends AbstractCaseCopyStrategy implements CaseCopyStrategy {
 
     private static final String[] DATA_CLOB_KEYS = {
+            "BusArea",
             "CatLost",
             "CatRude",
             "Channel",
@@ -25,6 +26,7 @@ public class CopyCompToComp2 extends AbstractCaseCopyStrategy implements CaseCop
             "Severity",
             "CatRacism",
             "CatUnfair",
+            "EnqReason",
             "OwningCSU",
             "CatAssault",
             "CatCCAvail",
@@ -33,6 +35,7 @@ public class CopyCompToComp2 extends AbstractCaseCopyStrategy implements CaseCop
             "CatAdminErr",
             "CatCCHandle",
             "CatPoorComm",
+            "LoaRequired",
             "PrevUkviRef",
             "CatCustodyBF",
             "CatWrongInfo",


### PR DESCRIPTION
Three fields were missing when escalating a complaints case from stage 1 to stage 2. This adds the three fields to the copy class.