### PR TITLE
HOCS-3852 Make contribution processing handle leading zeros

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspector.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspector.java
@@ -6,6 +6,7 @@ import com.jayway.jsonpath.ReadContext;
 import uk.gov.digital.ho.hocs.casework.domain.model.SomuItem;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 public class ContributionSomuInspector {
     private final ReadContext ctx;
@@ -33,7 +34,8 @@ public class ContributionSomuInspector {
     }
 
     public LocalDate getContributionDueLocalDate() {
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("y-M-d");
         String contributionDueDate = getContributionDueDate();
-        return LocalDate.parse(contributionDueDate);
+        return LocalDate.parse(contributionDueDate, dtf);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsDateProcessingTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsDateProcessingTest.java
@@ -1,0 +1,46 @@
+package uk.gov.digital.ho.hocs.casework.contributions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContributionsDateProcessingTest {
+
+    @Mock
+    ContributionSomuInspector contributionSomuInspector;
+
+    @Before
+    public void setup(){
+        when(contributionSomuInspector.getContributionDueLocalDate()).thenCallRealMethod();
+    }
+
+    @Test
+    public void testGetContributionDateWithNiceFormatting(){
+        when(contributionSomuInspector.getContributionDueDate()).thenReturn("2021-09-27");
+        LocalDate localDate = LocalDate.of(2021, 9, 27);
+        assertEquals(localDate, contributionSomuInspector.getContributionDueLocalDate());
+    }
+
+    @Test
+    public void testGetContributionDateWithLeadingZeros(){
+        when(contributionSomuInspector.getContributionDueDate()).thenReturn("02021-00009-0000027");
+        LocalDate localDate = LocalDate.of(2021, 9, 27);
+        assertEquals(localDate, contributionSomuInspector.getContributionDueLocalDate());
+    }
+
+    @Test
+    public void testGetContributionDateNoZeros(){
+        when(contributionSomuInspector.getContributionDueDate()).thenReturn("2021-9-7");
+        LocalDate localDate = LocalDate.of(2021, 9, 7);
+        assertEquals(localDate, contributionSomuInspector.getContributionDueLocalDate());
+    }
+
+}


### PR DESCRIPTION
Adds a datetimeformatter to let LocalDate.parse() handle leading zeros and also a lack of zeros. 