### PR TITLE
HOCS-3848: pass-through contribution status

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
@@ -31,15 +31,8 @@ public class ContributionsProcessorImpl implements ContributionsProcessor {
     public void processContributionsForStage(Stage stage) {
         Set<SomuItem> contributionSomuItems = somuItemService.getCaseSomuItemsBySomuType(stage.getCaseUUID());
 
-        if (MPAMContributionStages.contains(stage.getStageType())) {
-            calculateDueContributionDate(contributionSomuItems)
-                    .ifPresent(ld -> {
-                        log.info("Setting contribution date {}, for caseId {}", ld, stage.getCaseUUID());
-                        stage.setDueContribution(ld.toString());
-                    });
-        }
-
-        if (COMPLIANT_CASE_TYPE.equals(stage.getCaseDataType())) {
+        if (MPAMContributionStages.contains(stage.getStageType()) ||
+                COMPLIANT_CASE_TYPE.equals(stage.getCaseDataType())) {
             calculateDueContributionDate(contributionSomuItems)
                     .ifPresent(ld -> {
                         log.info("Setting contribution date {}, for caseId {}", ld, stage.getCaseUUID());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
@@ -36,7 +36,7 @@ public class ContributionsProcessorTest {
     }
 
     @Test
-    public void shouldAddContributionsForCompCase() {
+    public void shouldAddOverdueContributionsForCompCase() {
         String stageType = "COMP";
         Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
         doReturn("COMP").when(stage).getCaseDataType();
@@ -47,10 +47,26 @@ public class ContributionsProcessorTest {
 
         contributionsProcessor.processContributionsForStage(stage);
         assertEquals("2020-10-10", stage.getDueContribution());
+        assertEquals("Overdue", stage.getContributions());
     }
 
     @Test
-    public void shouldAddContributionsForMPAMCase() {
+    public void shouldAddDueContributionsForCompCase() {
+        String stageType = "COMP";
+        Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
+        doReturn("COMP").when(stage).getCaseDataType();
+
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
+
+        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID)).thenReturn(Set.of(somuItem));
+
+        contributionsProcessor.processContributionsForStage(stage);
+        assertEquals("9999-10-10", stage.getDueContribution());
+        assertEquals("Due", stage.getContributions());
+    }
+
+    @Test
+    public void shouldAddOverdueContributionsForMPAMCase() {
         String stageType = "MPAM_TRIAGE";
         Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
         doReturn("MPAM_TRIAGE").when(stage).getStageType();
@@ -61,6 +77,22 @@ public class ContributionsProcessorTest {
 
         contributionsProcessor.processContributionsForStage(stage);
         assertEquals("2020-10-10", stage.getDueContribution());
+        assertEquals("Overdue", stage.getContributions());
+    }
+
+    @Test
+    public void shouldAddDueContributionsForMPAMCase() {
+        String stageType = "MPAM_TRIAGE";
+        Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
+        doReturn("MPAM_TRIAGE").when(stage).getStageType();
+
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
+
+        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID)).thenReturn(Set.of(somuItem));
+
+        contributionsProcessor.processContributionsForStage(stage);
+        assertEquals("9999-10-10", stage.getDueContribution());
+        assertEquals("Due", stage.getContributions());
     }
 
     @Test


### PR DESCRIPTION
This change passes through the highest contribution status for a MPAM
case. This allows us to be able to differentiate between a case that is
received (and thus there is no due contribution) and those cases that
don't have any.