### PR TITLE
HOCS-3730 add organisation field to correspondent

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentResource.java
@@ -38,7 +38,7 @@ public class CorrespondentResource {
     @PostMapping(value = "/case/{caseUUID}/stage/{stageUUID}/correspondent")
     ResponseEntity addCorrespondentToCase(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID, @Valid @RequestBody CreateCorrespondentRequest request) {
         Address address = new Address(request.getPostcode(), request.getAddress1(), request.getAddress2(), request.getAddress3(), request.getCountry());
-        correspondentService.createCorrespondent(caseUUID, stageUUID, request.getType(), request.getFullname(), address, request.getTelephone(), request.getEmail(), request.getReference(), request.getExternalKey());
+        correspondentService.createCorrespondent(caseUUID, stageUUID, request.getType(), request.getFullname(), request.getOrganisation(), address, request.getTelephone(), request.getEmail(), request.getReference(), request.getExternalKey());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentService.java
@@ -124,9 +124,9 @@ public class CorrespondentService {
         return correspondentTypes;
     }
 
-    void createCorrespondent(UUID caseUUID, UUID stageUUID, String correspondentType, String fullname, Address address, String telephone, String email, String reference, String externalKey) {
+    void createCorrespondent(UUID caseUUID, UUID stageUUID, String correspondentType, String fullname, String organisation, Address address, String telephone, String email, String reference, String externalKey) {
         log.debug("Creating Correspondent of Type: {} for Case: {}", correspondentType, caseUUID);
-        Correspondent correspondent = new Correspondent(caseUUID, correspondentType, fullname, address, telephone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, correspondentType, fullname, organisation, address, telephone, email, reference, externalKey);
         try {
             correspondentRepository.save(correspondent);
             auditClient.createCorrespondentAudit(correspondent);
@@ -147,6 +147,7 @@ public class CorrespondentService {
         createCorrespondent(caseUUID, null,
                 correspondent.getCorrespondentType(),
                 correspondent.getFullName(),
+                correspondent.getOrganisation(),
                 Address.builder()
                         .address1(correspondent.getAddress1())
                         .address2(correspondent.getAddress2())
@@ -164,6 +165,7 @@ public class CorrespondentService {
         log.debug("Updating Correspondent: {} for Case: {}", correspondentUUID, caseUUID);
         Correspondent correspondent = getCorrespondent(caseUUID, correspondentUUID);
         correspondent.setFullName(updateCorrespondentRequest.getFullname());
+        correspondent.setOrganisation(updateCorrespondentRequest.getOrganisation());
         correspondent.setAddress1(updateCorrespondentRequest.getAddress1());
         correspondent.setAddress2(updateCorrespondentRequest.getAddress2());
         correspondent.setAddress3(updateCorrespondentRequest.getAddress3());

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateCorrespondentRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateCorrespondentRequest.java
@@ -21,6 +21,9 @@ public class CreateCorrespondentRequest {
     @JsonProperty(value = "fullname", required = true)
     String fullname;
 
+    @JsonProperty(value = "organisation")
+    String organisation;
+
     @JsonProperty("postcode")
     String postcode;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentResponse.java
@@ -28,6 +28,9 @@ public class GetCorrespondentResponse {
     @JsonProperty("fullname")
     private String fullname;
 
+    @JsonProperty("organisation")
+    private String organisation;
+
     @JsonProperty("address")
     private AddressDto address;
 
@@ -50,6 +53,7 @@ public class GetCorrespondentResponse {
                 correspondent.getCorrespondentType(),
                 correspondent.getCaseUUID(),
                 correspondent.getFullName(),
+                correspondent.getOrganisation(),
                 AddressDto.from(correspondent),
                 correspondent.getTelephone(),
                 correspondent.getEmail(),

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponse.java
@@ -31,6 +31,9 @@ public class GetCorrespondentWithPrimaryFlagResponse {
     @JsonProperty("fullname")
     private String fullname;
 
+    @JsonProperty("organisation")
+    private String organisation;
+
     @JsonProperty("address")
     private AddressDto address;
 
@@ -57,6 +60,7 @@ public class GetCorrespondentWithPrimaryFlagResponse {
                 correspondent.getCorrespondentTypeName(),
                 correspondent.getCaseUUID(),
                 correspondent.getFullName(),
+                correspondent.getOrganisation(),
                 AddressDto.from(correspondent),
                 correspondent.getTelephone(),
                 correspondent.getEmail(),

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/UpdateCorrespondentRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/UpdateCorrespondentRequest.java
@@ -17,6 +17,9 @@ public class UpdateCorrespondentRequest {
     @JsonProperty(value = "fullname", required = true)
     String fullname;
 
+    @JsonProperty("organisation")
+    String organisation;
+
     @JsonProperty("postcode")
     String postcode;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseCorrespondent.java
@@ -45,6 +45,11 @@ public abstract class BaseCorrespondent implements Serializable {
 
     @Setter
     @Getter
+    @Column(name = "organisation")
+    protected String organisation;
+
+    @Setter
+    @Getter
     @Column(name = "postcode")
     protected String postcode;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Correspondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Correspondent.java
@@ -19,6 +19,7 @@ public class Correspondent extends BaseCorrespondent {
     public Correspondent(UUID caseUUID,
                          String correspondentType,
                          String fullName,
+                         String organisation,
                          Address address,
                          String telephone,
                          String email,
@@ -33,6 +34,7 @@ public class Correspondent extends BaseCorrespondent {
         this.caseUUID = caseUUID;
         this.correspondentType = correspondentType;
         this.fullName = fullName;
+        this.organisation = organisation;
         if (address != null) {
             this.postcode = address.getPostcode();
             this.address1 = address.getAddress1();

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlag.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlag.java
@@ -26,6 +26,7 @@ public class CorrespondentWithPrimaryFlag extends BaseCorrespondent {
             UUID caseUUID,
             String correspondentType,
             String fullName,
+            String organisation,
             Address address,
             String telephone,
             String email,
@@ -42,6 +43,7 @@ public class CorrespondentWithPrimaryFlag extends BaseCorrespondent {
         this.caseUUID = caseUUID;
         this.correspondentType = correspondentType;
         this.fullName = fullName;
+        this.organisation = organisation;
         if (address != null) {
             this.postcode = address.getPostcode();
             this.address1 = address.getAddress1();

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/MigrationCorrespondentResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/MigrationCorrespondentResource.java
@@ -27,7 +27,7 @@ public class MigrationCorrespondentResource {
     @PostMapping(value = "/migration/case/{caseUUID}/stage/{stageUUID}/correspondent")
     ResponseEntity<UUID> addCorrespondentToCase(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID, @Valid @RequestBody CreateCorrespondentRequest request) {
         Address address = new Address(request.getPostcode(), request.getAddress1(), request.getAddress2(), request.getAddress3(), request.getCountry());
-        UUID correspondentUUID = migrationCorrespondentService.createCorrespondent(caseUUID, request.getType(), request.getFullname(), address, request.getTelephone(), request.getEmail(), request.getReference(), request.getExternalKey());
+        UUID correspondentUUID = migrationCorrespondentService.createCorrespondent(caseUUID, request.getType(), request.getFullname(), request.getOrganisation(), address, request.getTelephone(), request.getEmail(), request.getReference(), request.getExternalKey());
         return ResponseEntity.ok(correspondentUUID);
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/MigrationCorrespondentService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/MigrationCorrespondentService.java
@@ -25,9 +25,9 @@ public class MigrationCorrespondentService {
         this.correspondentRepository = correspondentRepository;
     }
 
-    UUID createCorrespondent(UUID caseUUID, String correspondentType, String fullname, Address address, String telephone, String email, String reference, String externalKey) {
+    UUID createCorrespondent(UUID caseUUID, String correspondentType, String fullname, String organisation, Address address, String telephone, String email, String reference, String externalKey) {
         log.debug("Creating Correspondent of Type: {} for Case: {}", correspondentType, caseUUID);
-        Correspondent correspondent = new Correspondent(caseUUID, correspondentType, fullname, address, telephone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, correspondentType, fullname, organisation, address, telephone, email, reference, externalKey);
         try {
             correspondentRepository.save(correspondent);
 

--- a/src/main/resources/db/migration/postgresql/V1_20__3730-Add-Organisation-Field.sql
+++ b/src/main/resources/db/migration/postgresql/V1_20__3730-Add-Organisation-Field.sql
@@ -1,0 +1,16 @@
+SET search_path TO casework;
+
+ALTER TABLE correspondent
+    ADD COLUMN organisation TEXT;
+
+CREATE OR REPLACE VIEW active_correspondent AS
+  SELECT c.*
+  FROM correspondent c
+         JOIN active_case ac ON c.case_uuid = ac.uuid
+  WHERE NOT c.deleted;
+
+CREATE OR REPLACE VIEW primary_correspondent AS
+  SELECT c.*
+  FROM correspondent c
+         JOIN active_case ac ON c.uuid = ac.primary_correspondent_uuid
+  WHERE NOT c.deleted;

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
@@ -153,7 +153,7 @@ public class CaseDataResourceTest {
     @Test
     public void shouldGetCaseWithCorrespondentAndTopic() {
 
-        Correspondent correspondent = new Correspondent(UUID.randomUUID(), "TYPE", "name",
+        Correspondent correspondent = new Correspondent(UUID.randomUUID(), "TYPE", "name", "organisation",
                 new Address("postcode", "address1", "address2", "address3", "county"),
                 "phone", "email", "", "");
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -76,6 +76,7 @@ public class CaseDataServiceTest {
     public static final String PREVIOUS_CASE_TYPE = "COMP";
     public static final String PREV_CORRESPONDENT_TYPE = "correspondent_type";
     public static final String PREV_FULLNAME = "fullname";
+    public static final String PREV_ORGANISATION = "organisation";
     public static final String PREV_ADDR_1 = "addr1";
     public static final String PREV_ADDR_2 = "addr2";
     public static final String PREV_ADDR_3 = "addr3";
@@ -184,6 +185,7 @@ public class CaseDataServiceTest {
                 new Correspondent(PREVIOUS_CASE_UUID,
                 PREV_CORRESPONDENT_TYPE,
                 PREV_FULLNAME,
+                PREV_ORGANISATION,
                 new Address(PREV_ADDR_1,
                         PREV_ADDR_2,
                         PREV_ADDR_3,

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentResourceTest.java
@@ -51,12 +51,12 @@ public class CorrespondentResourceTest {
 
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
 
-        doNothing().when(correspondentService).createCorrespondent(eq(caseUUID), eq(stageUUID), eq("any"), eq("anyFullName"), any(Address.class), eq("anyPhone"), eq("anyEmail"), eq("anyReference"), eq("external key"));
+        doNothing().when(correspondentService).createCorrespondent(eq(caseUUID), eq(stageUUID), eq("any"), eq("anyFullName"), eq("organisation"), any(Address.class), eq("anyPhone"), eq("anyEmail"), eq("anyReference"), eq("external key"));
 
-        CreateCorrespondentRequest createCorrespondentRequest = new CreateCorrespondentRequest("any", "anyFullName","anyPostcode", "any1", "any2", "any3", "anyCountry", "anyPhone", "anyEmail", "anyReference", "external key");
+        CreateCorrespondentRequest createCorrespondentRequest = new CreateCorrespondentRequest("any", "anyFullName", "organisation", "anyPostcode", "any1", "any2", "any3", "anyCountry", "anyPhone", "anyEmail", "anyReference", "external key");
         ResponseEntity response = correspondentResource.addCorrespondentToCase(caseUUID, stageUUID, createCorrespondentRequest);
 
-        verify(correspondentService, times(1)).createCorrespondent(eq(caseUUID), eq(stageUUID), eq("any"), eq("anyFullName"), any(Address.class), eq("anyPhone"), eq("anyEmail"), eq("anyReference"), eq("external key"));
+        verify(correspondentService, times(1)).createCorrespondent(eq(caseUUID), eq(stageUUID), eq("any"), eq("anyFullName"), eq("organisation"),  any(Address.class), eq("anyPhone"), eq("anyEmail"), eq("anyReference"), eq("external key"));
 
         verifyNoMoreInteractions(correspondentService);
 
@@ -83,7 +83,7 @@ public class CorrespondentResourceTest {
     public void shouldGetCorrespondent() {
 
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        Correspondent correspondent = new Correspondent(caseUUID, "CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        Correspondent correspondent = new Correspondent(caseUUID, "CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
 
         when(correspondentService.getCorrespondent(caseUUID, correspondentUUID)).thenReturn(correspondent);
 
@@ -131,7 +131,7 @@ public class CorrespondentResourceTest {
 
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
 
-        UpdateCorrespondentRequest updateCorrespondentRequest = new UpdateCorrespondentRequest("anyFullName","anyPostcode", "any1", "any2", "any3", "anyCountry", "anyPhone", "anyEmail", "anyReference");
+        UpdateCorrespondentRequest updateCorrespondentRequest = new UpdateCorrespondentRequest("anyFullName", "organisation","anyPostcode", "any1", "any2", "any3", "anyCountry", "anyPhone", "anyEmail", "anyReference");
         doNothing().when(correspondentService).updateCorrespondent(eq(caseUUID), eq(correspondentUUID), eq(updateCorrespondentRequest));
 
         ResponseEntity response = correspondentResource.updateCorrespondent(caseUUID, stageUUID, correspondentUUID, updateCorrespondentRequest);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CorrespondentServiceTest.java
@@ -126,6 +126,7 @@ public class CorrespondentServiceTest {
         return new CorrespondentWithPrimaryFlag(correspondent.getCaseUUID(),
                 correspondent.getCorrespondentType(),
                 correspondent.getFullName(),
+                correspondent.getOrganisation(),
                 Address.builder()
                         .postcode(correspondent.getPostcode())
                         .address1(correspondent.getAddress1())
@@ -144,12 +145,13 @@ public class CorrespondentServiceTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "A Large Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
         return correspondent;
     }
 
@@ -179,6 +181,7 @@ public class CorrespondentServiceTest {
           caseUUID,
           "Type",
           "full name",
+                "organisation",
                 address,
                 "01923478393",
                 "email@test.com",
@@ -207,6 +210,7 @@ public class CorrespondentServiceTest {
                 caseUUID,
                 "Type",
                 "full name",
+                "organisation",
                 address,
                 "01923478393",
                 "email@test.com",
@@ -237,6 +241,7 @@ public class CorrespondentServiceTest {
                 caseUUID,
                 "Type",
                 "full name",
+                "organisation",
                 address,
                 "01923478393",
                 "email@test.com",
@@ -268,6 +273,7 @@ public class CorrespondentServiceTest {
         UUID testCaseUUID = UUID.randomUUID();
         UUID testCorrespondenceUUID = UUID.randomUUID();
         @NotEmpty String testFullname = "test name";
+        String testOrganisation = "Organisation";
         String testPostcode = "T3 5ST";
         String testAdd1 = "Test House";
         String testAdd2 = "Test Street";
@@ -279,6 +285,7 @@ public class CorrespondentServiceTest {
 
         UpdateCorrespondentRequest  testRequest = new UpdateCorrespondentRequest(
                 testFullname,
+                testOrganisation,
                 testPostcode,
                 testAdd1,
                 testAdd2,
@@ -290,7 +297,7 @@ public class CorrespondentServiceTest {
         );
 
 
-        Correspondent mockDBResponse = new Correspondent(testCaseUUID, "SomeType" ,testFullname, null, null, null, null, null);
+        Correspondent mockDBResponse = new Correspondent(testCaseUUID, "SomeType" ,testFullname, null, null, null, null, null, null);
         when(correspondentRepository.findByUUID(testCaseUUID, testCorrespondenceUUID)).thenReturn(mockDBResponse);
         when(caseDataRepository.getCaseType(testCaseUUID)).thenReturn("TEST");
         CorrespondentTypeDto correspondentTypeDto = new CorrespondentTypeDto();

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/MigrationCorrespondentServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/MigrationCorrespondentServiceTest.java
@@ -55,6 +55,7 @@ public class MigrationCorrespondentServiceTest {
                 caseUUID,
                 "CORRESPONDENT",
                 "anyFullName",
+                "organisation",
                 address,
                 "anyPhone",
                 "anyEmail",
@@ -93,6 +94,7 @@ public class MigrationCorrespondentServiceTest {
                 caseUUID,
                 "CORRESPONDENT",
                 "anyFullName",
+                "organisation",
                 address,
                 "anyPhone",
                 "anyEmail",
@@ -102,7 +104,7 @@ public class MigrationCorrespondentServiceTest {
         );
 
         when(correspondentRepository.findAllByCaseUUID(caseUUID)).thenReturn(Set.of(correspondent));
-        correspondentService.createCorrespondent(caseUUID, stageUUID,"CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        correspondentService.createCorrespondent(caseUUID, stageUUID,"CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
 
         verify(correspondentRepository).save(any(Correspondent.class));
         verify(correspondentRepository).findAllByCaseUUID(caseUUID);
@@ -120,6 +122,7 @@ public class MigrationCorrespondentServiceTest {
                 caseUUID,
                 "CORRESPONDENT",
                 "anyFullName1",
+                "organisation",
                 address,
                 "anyPhone1",
                 "anyEmail1",
@@ -131,6 +134,7 @@ public class MigrationCorrespondentServiceTest {
                 caseUUID,
                 "CORRESPONDENT",
                 "anyFullName2",
+                "organisation",
                 address,
                 "anyPhone2",
                 "anyEmail2",
@@ -140,7 +144,7 @@ public class MigrationCorrespondentServiceTest {
         );
 
         when(correspondentRepository.findAllByCaseUUID(caseUUID)).thenReturn(Set.of(correspondent1, correspondent2));
-        correspondentService.createCorrespondent(caseUUID, stageUUID,"CORRESPONDENT", "anyFullName2", address, "anyPhone2", "anyEmail2", "anyReference2", "external key2");
+        correspondentService.createCorrespondent(caseUUID, stageUUID,"CORRESPONDENT", "anyFullName2", "organisation", address, "anyPhone2", "anyEmail2", "anyReference2", "external key2");
 
         verify(correspondentRepository).save(any(Correspondent.class));
         verify(correspondentRepository).findAllByCaseUUID(caseUUID);
@@ -152,7 +156,7 @@ public class MigrationCorrespondentServiceTest {
     public void shouldAuditCreateCorrespondent() throws ApplicationExceptions.EntityCreationException {
 
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        correspondentService.createCorrespondent(caseUUID, stageUUID, "CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        correspondentService.createCorrespondent(caseUUID, stageUUID, "CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
 
         verify(auditClient, times(1)).createCorrespondentAudit(any(Correspondent.class));
 
@@ -162,14 +166,14 @@ public class MigrationCorrespondentServiceTest {
     @Test(expected = ApplicationExceptions.EntityCreationException.class)
     public void shouldNotCreateCorrespondentMissingCaseUUIDException() throws ApplicationExceptions.EntityCreationException {
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        correspondentService.createCorrespondent(null, stageUUID, "CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        correspondentService.createCorrespondent(null, stageUUID, "CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
     }
 
     @Test
     public void shouldNotCreateCorrespondentMissingCaseUUID() {
         try {
             Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-            correspondentService.createCorrespondent(null, stageUUID, "CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+            correspondentService.createCorrespondent(null, stageUUID, "CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
         } catch (ApplicationExceptions.EntityCreationException e) {
             // Do nothing.
         }
@@ -180,7 +184,7 @@ public class MigrationCorrespondentServiceTest {
     @Test(expected = ApplicationExceptions.EntityCreationException.class)
     public void shouldNotCreateCorrespondentMissingCorrespondentTypeException() throws ApplicationExceptions.EntityCreationException {
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        correspondentService.createCorrespondent(caseUUID, stageUUID, null, "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        correspondentService.createCorrespondent(caseUUID, stageUUID, null, "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
     }
 
     @Test
@@ -188,7 +192,7 @@ public class MigrationCorrespondentServiceTest {
 
         try {
             Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-            correspondentService.createCorrespondent(caseUUID, stageUUID, null, "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+            correspondentService.createCorrespondent(caseUUID, stageUUID, null, "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
         } catch (ApplicationExceptions.EntityCreationException e) {
             // Do nothing.
         }
@@ -200,7 +204,7 @@ public class MigrationCorrespondentServiceTest {
     @Test
     public void shouldGetCorrespondent() throws ApplicationExceptions.EntityNotFoundException {
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
-        Correspondent correspondent = new Correspondent(caseUUID, "CORRESPONDENT", "anyFullName", address, "anyPhone", "anyEmail", "anyReference", "external key");
+        Correspondent correspondent = new Correspondent(caseUUID, "CORRESPONDENT", "anyFullName", "organisation", address, "anyPhone", "anyEmail", "anyReference", "external key");
         Set<CorrespondentTypeDto> emptyCorrespondentSet = Collections.emptySet();
 
         when(correspondentRepository.findByUUID(correspondent.getCaseUUID(), correspondent.getUuid())).thenReturn(correspondent);
@@ -268,7 +272,7 @@ public class MigrationCorrespondentServiceTest {
 
     @Test
     public void shouldDeleteCorrespondent() {
-        Correspondent correspondent = new Correspondent(caseUUID, "any", null, null, null, null, null, null);
+        Correspondent correspondent = new Correspondent(caseUUID, "any", null, null, null, null, null, null, null);
         Set<CorrespondentTypeDto> emptyCorrespondentSet = Collections.emptySet();
 
         when(correspondentRepository.findByUUID(correspondent.getCaseUUID(), correspondent.getUuid())).thenReturn(correspondent);
@@ -286,7 +290,7 @@ public class MigrationCorrespondentServiceTest {
 
     @Test
     public void shouldAuditDeleteCorrespondent() {
-        Correspondent correspondent = new Correspondent(caseUUID, "any", null, null, null, null, null, null);
+        Correspondent correspondent = new Correspondent(caseUUID, "any", null, null, null, null, null, null, null);
         Set<CorrespondentTypeDto> emptyCorrespondentSet = Collections.emptySet();
 
         when(correspondentRepository.findByUUID(correspondent.getCaseUUID(), correspondent.getUuid())).thenReturn(correspondent);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentOutlineResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentOutlineResponseTest.java
@@ -15,12 +15,13 @@ public class GetCorrespondentOutlineResponseTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
 
         GetCorrespondentOutlineResponse getCorrespondentOutlineResponse = GetCorrespondentOutlineResponse.from(correspondent);
 
@@ -32,7 +33,7 @@ public class GetCorrespondentOutlineResponseTest {
     public void getCorrespondentOutlineResponseFromNullDto() {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
-        Correspondent correspondent = new Correspondent(caseUUID, type, null, null, null, null, null, null);
+        Correspondent correspondent = new Correspondent(caseUUID, type, null, null, null, null, null, null, null);
 
         GetCorrespondentOutlineResponse getCorrespondentOutlineResponse = GetCorrespondentOutlineResponse.from(correspondent);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentOutlinesResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentOutlinesResponseTest.java
@@ -18,12 +18,13 @@ public class GetCorrespondentOutlinesResponseTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
         Set<Correspondent> correspondents = Set.of(correspondent);
 
         GetCorrespondentOutlinesResponse getCorrespondentOutlinesResponse = GetCorrespondentOutlinesResponse.from(correspondents);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentResponseTest.java
@@ -16,13 +16,14 @@ public class GetCorrespondentResponseTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
 
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
 
         GetCorrespondentResponse getCorrespondentResponse = GetCorrespondentResponse.from(correspondent);
 
@@ -31,6 +32,7 @@ public class GetCorrespondentResponseTest {
         assertThat(getCorrespondentResponse.getType()).isEqualTo(correspondent.getCorrespondentType());
         assertThat(getCorrespondentResponse.getCaseUUID()).isEqualTo(correspondent.getCaseUUID());
         assertThat(getCorrespondentResponse.getFullname()).isEqualTo(correspondent.getFullName());
+        assertThat(getCorrespondentResponse.getOrganisation()).isEqualTo(correspondent.getOrganisation());
 
         assertThat(getCorrespondentResponse.getAddress().getPostcode()).isEqualTo(correspondent.getPostcode());
         assertThat(getCorrespondentResponse.getAddress().getAddress1()).isEqualTo(correspondent.getAddress1());
@@ -51,7 +53,7 @@ public class GetCorrespondentResponseTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
 
-        Correspondent correspondent = new Correspondent(caseUUID, type, null, null, null, null, null, null);
+        Correspondent correspondent = new Correspondent(caseUUID, type, null, null, null, null, null, null, null);
 
         GetCorrespondentResponse getCorrespondentResponse = GetCorrespondentResponse.from(correspondent);
 
@@ -60,6 +62,7 @@ public class GetCorrespondentResponseTest {
         assertThat(getCorrespondentResponse.getType()).isEqualTo(correspondent.getCorrespondentType());
         assertThat(getCorrespondentResponse.getCaseUUID()).isEqualTo(correspondent.getCaseUUID());
         assertThat(getCorrespondentResponse.getFullname()).isEqualTo(correspondent.getFullName());
+        assertThat(getCorrespondentResponse.getOrganisation()).isEqualTo(correspondent.getOrganisation());
         assertThat(getCorrespondentResponse.getAddress().getPostcode()).isEqualTo(correspondent.getPostcode());
         assertThat(getCorrespondentResponse.getAddress().getAddress1()).isEqualTo(correspondent.getAddress1());
         assertThat(getCorrespondentResponse.getAddress().getAddress2()).isEqualTo(correspondent.getAddress2());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentWithPrimaryFlagResponseTest.java
@@ -16,6 +16,7 @@ public class GetCorrespondentWithPrimaryFlagResponseTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
@@ -27,6 +28,7 @@ public class GetCorrespondentWithPrimaryFlagResponseTest {
                 caseUUID,
                 type,
                 fullName,
+                organisation,
                 address,
                 phone,
                 email,
@@ -43,6 +45,7 @@ public class GetCorrespondentWithPrimaryFlagResponseTest {
         assertThat(getCorrespondentResponse.getType()).isEqualTo(correspondent.getCorrespondentType());
         assertThat(getCorrespondentResponse.getCaseUUID()).isEqualTo(correspondent.getCaseUUID());
         assertThat(getCorrespondentResponse.getFullname()).isEqualTo(correspondent.getFullName());
+        assertThat(getCorrespondentResponse.getOrganisation()).isEqualTo(correspondent.getOrganisation());
         assertThat(getCorrespondentResponse.getAddress().getPostcode()).isEqualTo(correspondent.getPostcode());
         assertThat(getCorrespondentResponse.getAddress().getAddress1()).isEqualTo(correspondent.getAddress1());
         assertThat(getCorrespondentResponse.getAddress().getAddress2()).isEqualTo(correspondent.getAddress2());
@@ -72,6 +75,7 @@ public class GetCorrespondentWithPrimaryFlagResponseTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 
@@ -83,6 +87,7 @@ public class GetCorrespondentWithPrimaryFlagResponseTest {
         assertThat(getCorrespondentResponse.getType()).isEqualTo(correspondent.getCorrespondentType());
         assertThat(getCorrespondentResponse.getCaseUUID()).isEqualTo(correspondent.getCaseUUID());
         assertThat(getCorrespondentResponse.getFullname()).isEqualTo(correspondent.getFullName());
+        assertThat(getCorrespondentResponse.getOrganisation()).isEqualTo(correspondent.getOrganisation());
         assertThat(getCorrespondentResponse.getAddress().getPostcode()).isEqualTo(correspondent.getPostcode());
         assertThat(getCorrespondentResponse.getAddress().getAddress1()).isEqualTo(correspondent.getAddress1());
         assertThat(getCorrespondentResponse.getAddress().getAddress2()).isEqualTo(correspondent.getAddress2());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentsResponseTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCorrespondentsResponseTest.java
@@ -16,6 +16,7 @@ public class GetCorrespondentsResponseTest {
             UUID.randomUUID(),
             "CORRESPONDENT",
             "anyFullName",
+            "anyOrganisation",
             new Address("anyPostcode", "any1", "any2", "any3", "anyCountry"),
             "anyPhone",
             "anyEmail",

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2Test.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2Test.java
@@ -47,6 +47,7 @@ public class CopyCompToComp2Test {
     private static final UUID FROM_CASE_UUID = UUID.randomUUID();
     private static final String CORRESPONDENT_TYPE = "correspondent_type";
     private static final String FULLNAME = "fullname";
+    private static final String ORGANISATION = "organisation";
     private static final String ADDRESS_1 = "address1";
     private static final String ADDRESS_2 = "address2";
     private static final String ADDRESS_3 = "address3";
@@ -59,6 +60,7 @@ public class CopyCompToComp2Test {
     private static final Correspondent PRIMARY_CORRESPONDENT = new Correspondent(FROM_CASE_UUID,
             CORRESPONDENT_TYPE,
             FULLNAME,
+            ORGANISATION,
             Address.builder()
                     .address1(ADDRESS_1)
                     .address2(ADDRESS_2)

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecoratorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/utils/CorrespondentTypeNameDecoratorTest.java
@@ -26,6 +26,7 @@ public class CorrespondentTypeNameDecoratorTest {
                 UUID.randomUUID(),
                 "Type",
                 "full name",
+                "organisation",
                 address,
                 "01923478393",
                 "email@test.com",

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClientTest.java
@@ -65,7 +65,7 @@ public class AuditClientTest {
     private LocalDate caseReceived = LocalDate.now();
     private String auditQueue ="audit-queue";
     private Address address = new Address("S1 3NS","some street","some town","some count","UK");
-    private Correspondent correspondent = new Correspondent(randomUUID(), "MP", "John Smith", address, "123456789","test@test.com", "1234", "external key" );
+    private Correspondent correspondent = new Correspondent(randomUUID(), "MP", "John Smith", "An Organisation", address, "123456789","test@test.com", "1234", "external key" );
     private Topic topic = new Topic(caseUUID, "some topic", randomUUID());
 
     @Captor

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentTest.java
@@ -16,19 +16,21 @@ public class CorrespondentTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "anyOrganisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
 
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
 
         assertThat(correspondent.getUuid()).isOfAnyClassIn(UUID.randomUUID().getClass());
         assertThat(correspondent.getCreated()).isOfAnyClassIn(LocalDateTime.now().getClass());
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -47,19 +49,21 @@ public class CorrespondentTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "anyOrganisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
 
-        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, address, phone, email, reference, externalKey);
+        Correspondent correspondent = new Correspondent(caseUUID, type, fullName, organisation, address, phone, email, reference, externalKey);
 
         assertThat(correspondent.getUuid()).isOfAnyClassIn(UUID.randomUUID().getClass());
         assertThat(correspondent.getCreated()).isOfAnyClassIn(LocalDateTime.now().getClass());
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -78,6 +82,7 @@ public class CorrespondentTest {
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -95,13 +100,14 @@ public class CorrespondentTest {
 
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "anyOrganisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
 
-        new Correspondent(null, type, fullName, address, phone, email, reference, externalKey);
+        new Correspondent(null, type, fullName, organisation, address, phone, email, reference, externalKey);
 
     }
 
@@ -110,13 +116,14 @@ public class CorrespondentTest {
 
         UUID caseUUID = UUID.randomUUID();
         String fullName = "anyFullName";
+        String organisation = "anyOrganisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
         String reference = "anyReference";
         String externalKey = "external key";
 
-        new Correspondent(caseUUID, null, fullName, address, phone, email, reference, externalKey);
+        new Correspondent(caseUUID, null, fullName, organisation, address, phone, email, reference, externalKey);
 
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlagTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/CorrespondentWithPrimaryFlagTest.java
@@ -16,6 +16,7 @@ public class CorrespondentWithPrimaryFlagTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
@@ -27,6 +28,7 @@ public class CorrespondentWithPrimaryFlagTest {
                 caseUUID,
                 type,
                 fullName,
+                organisation,
                 address,
                 phone,
                 email,
@@ -40,6 +42,7 @@ public class CorrespondentWithPrimaryFlagTest {
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -59,6 +62,7 @@ public class CorrespondentWithPrimaryFlagTest {
         UUID caseUUID = UUID.randomUUID();
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
@@ -70,6 +74,7 @@ public class CorrespondentWithPrimaryFlagTest {
                 caseUUID,
                 type,
                 fullName,
+                organisation,
                 address,
                 phone,
                 email,
@@ -82,6 +87,7 @@ public class CorrespondentWithPrimaryFlagTest {
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -101,6 +107,7 @@ public class CorrespondentWithPrimaryFlagTest {
         assertThat(correspondent.getCorrespondentType()).isEqualTo(type);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo(fullName);
+        assertThat(correspondent.getOrganisation()).isEqualTo(organisation);
         assertThat(correspondent.getPostcode()).isEqualTo(address.getPostcode());
         assertThat(correspondent.getAddress1()).isEqualTo(address.getAddress1());
         assertThat(correspondent.getAddress2()).isEqualTo(address.getAddress2());
@@ -120,6 +127,7 @@ public class CorrespondentWithPrimaryFlagTest {
         UUID caseUUID = null;
         String type = "CORRESPONDENT";
         String fullName = "anyFullName";
+        String organisation = "An Organisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
@@ -131,6 +139,7 @@ public class CorrespondentWithPrimaryFlagTest {
                 caseUUID,
                 type,
                 fullName,
+                organisation,
                 address,
                 phone,
                 email,
@@ -146,6 +155,7 @@ public class CorrespondentWithPrimaryFlagTest {
 
         UUID caseUUID = UUID.randomUUID();
         String fullName = "anyFullName";
+        String organisation = "anyOrganisation";
         Address address = new Address("anyPostcode", "any1", "any2", "any3", "anyCountry");
         String phone = "anyPhone";
         String email = "anyEmail";
@@ -158,6 +168,7 @@ public class CorrespondentWithPrimaryFlagTest {
                 caseUUID,
                 type,
                 fullName,
+                organisation,
                 address,
                 phone,
                 email,

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/CorrespondentRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/CorrespondentRepositoryTest.java
@@ -55,6 +55,7 @@ public class CorrespondentRepositoryTest {
                 caseUUID,
                 "some_type",
                 "full name",
+                "organisation",
                 address,
                 "01923478393",
                 "email@test.com",
@@ -73,6 +74,7 @@ public class CorrespondentRepositoryTest {
         Correspondent correspondent = repository.findByUUID(caseUUID, correspondentUUID);
         assertThat(correspondent.getCaseUUID()).isEqualTo(caseUUID);
         assertThat(correspondent.getFullName()).isEqualTo("full name");
+        assertThat(correspondent.getOrganisation()).isEqualTo("organisation");
         assertThat(correspondent.getEmail()).isEqualTo("email@test.com");
         assertThat(correspondent.getReference()).isEqualTo("ref");
         assertThat(correspondent.getCorrespondentType()).isEqualTo("some_type");


### PR DESCRIPTION
Adds an Organisation field used in FOI requests, this field is stored in the Correspondent table.