### PR TITLE
HOCS-3858: get stage team through projection

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -105,7 +105,7 @@ public class StageService {
         Stage.StageTeamUuid stageTeamUuid = stageRepository.findTeamUuidByCaseUuidAndStageUuid(caseUUID, stageUUID);
 
         if (stageTeamUuid == null) {
-            log.info("No team exists is linked to stage: {} and case: {}", stageUUID, caseUUID);
+            log.warn("No team exists is linked to stage: {} and case: {}", stageUUID, caseUUID);
 
             return null;
         }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -102,9 +102,16 @@ public class StageService {
 
     public UUID getStageTeam(UUID caseUUID, UUID stageUUID) {
         log.debug("Getting Team for Stage: {}", stageUUID);
-        Stage stage = getStage(caseUUID, stageUUID);
-        log.debug("Got Team: {} for Stage: {}", stage.getTeamUUID(), stageUUID);
-        return stage.getTeamUUID();
+        Stage.StageTeamUuid stageTeamUuid = stageRepository.findTeamUuidByCaseUuidAndStageUuid(caseUUID, stageUUID);
+
+        if (stageTeamUuid == null) {
+            log.info("No team exists is linked to stage: {} and case: {}", stageUUID, caseUUID);
+
+            return null;
+        }
+
+        log.info("Team: {} exists is linked to stage: {} and case: {}", stageTeamUuid.getTeamUuid(), stageUUID, caseUUID, stageUUID);
+        return UUID.fromString(stageTeamUuid.getTeamUuid());
     }
 
     public String getStageTypeFromStageData(UUID caseUUID, UUID stageUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/Stage.java
@@ -21,6 +21,10 @@ import static uk.gov.digital.ho.hocs.casework.application.LogEvent.STAGE_CREATE_
 @Table(name = "stage")
 public class Stage extends AbstractJsonDataMap implements Serializable {
 
+    public interface StageTeamUuid {
+        String getTeamUuid();
+    }
+
     public static final String DCU_MIN_INITIAL_DRAFT = "DCU_MIN_INITIAL_DRAFT";
     public static final String DCU_TRO_INITIAL_DRAFT = "DCU_TRO_INITIAL_DRAFT";
     public static final String DCU_DTEN_INITIAL_DRAFT = "DCU_DTEN_INITIAL_DRAFT";

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -50,4 +50,8 @@ public interface StageRepository extends CrudRepository<Stage, Long> {
     @Query(value = "SELECT sd.* FROM stage_data sd join active_case ac on sd.case_uuid = ac.uuid where ac.reference = ?1", nativeQuery = true)
     Set<Stage> findByCaseReference(String reference);
 
+    @SuppressWarnings("SpringDataRepositoryMethodReturnTypeInspection") // caused by using 'By' in method name
+    @Query(value = "SELECT CAST(team_uuid AS VARCHAR(36)) AS teamUuid FROM stage WHERE case_uuid = ?1 AND uuid = ?2", nativeQuery = true)
+    Stage.StageTeamUuid findTeamUuidByCaseUuidAndStageUuid(UUID caseUuid, UUID stageUuid);
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -834,6 +834,38 @@ public class StageServiceTest {
         verifyNoMoreInteractions(stageRepository, notifyClient);
     }
 
+    @Test
+    public void getStageTeam_valid() {
+        var caseUuid = UUID.randomUUID();
+        var stageUuid = UUID.randomUUID();
+        var teamUUID = UUID.randomUUID();
+
+        when(stageRepository.findTeamUuidByCaseUuidAndStageUuid(any(), any())).thenReturn(teamUUID::toString);
+
+        var result = stageService.getStageTeam(caseUuid, stageUuid);
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).isEqualTo(teamUUID.toString());
+
+        verify(stageRepository).findTeamUuidByCaseUuidAndStageUuid(caseUuid, stageUuid);
+
+        verifyNoMoreInteractions(stageRepository);
+    }
+
+    @Test
+    public void getStageTeam_nullResult() {
+        var caseUuid = UUID.randomUUID();
+        var stageUuid = UUID.randomUUID();
+
+        when(stageRepository.findTeamUuidByCaseUuidAndStageUuid(any(), any())).thenReturn(null);
+
+        var result = stageService.getStageTeam(caseUuid, stageUuid);
+        assertThat(result).isNull();
+
+        verify(stageRepository).findTeamUuidByCaseUuidAndStageUuid(caseUuid, stageUuid);
+
+        verifyNoMoreInteractions(stageRepository);
+    }
+
     /**
      * The stage cannot be an instance as it does not have a function to set data (in the Stage Class).
      * I did not want to create a setData on the Stage class for testing only.

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
@@ -15,6 +15,8 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseLink;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class StageRepositoryTest {
 
     private static final long TEN_SECONDS = 10000L;
-    private static final int QRY_RUNS = 10;
     private static final UUID TEAM_UUID = UUID.randomUUID();
 
     @Autowired
@@ -38,39 +39,74 @@ public class StageRepositoryTest {
 
     @Test
     public void findAllActiveByTeamUUID() {
+        final int QUERY_RUNS = 10;
 
-        long[] timings = new long[QRY_RUNS];
-        long[] timingsWithValidTeam = new long[QRY_RUNS];
+        long[] timings = new long[QUERY_RUNS];
+        long[] timingsWithValidTeam = new long[QUERY_RUNS];
 
         // given
         createLargeDataSet(10000);
 
         // when
-        for (int i = 0; i < QRY_RUNS; i++) {
-            runQuery(UUID.randomUUID(), timings, i);
-            runQuery(TEAM_UUID, timingsWithValidTeam, i);
+        for (int i = 0; i < QUERY_RUNS; i++) {
+            runFindAllActiveByTeamUuidQuery(UUID.randomUUID(), timings, i);
+            runFindAllActiveByTeamUuidQuery(TEAM_UUID, timingsWithValidTeam, i);
         }
 
         // then
         log.info("Execution millis searching random team:{}, ", timings);
         log.info("Execution millis searching known team:{}, ", timingsWithValidTeam);
 
-        for (int i = 0; i < QRY_RUNS; i++) {
+        for (int i = 0; i < QUERY_RUNS; i++) {
             assertThat("Duration must be less than 10 seconds", timings[i] <= TEN_SECONDS);
             assertThat("Duration must be less than 10 seconds", timingsWithValidTeam[i] <= TEN_SECONDS);
         }
     }
 
-    private void runQuery(UUID team, long[] timings, int iteration) {
+    @Test
+    public void findTeamUuidByCaseUuidAndStageUuid() {
+        final int QUERY_AMOUNT = 100;
+        long[] timings = new long[QUERY_AMOUNT];
+
+        var stages = createCaseWithStages(10000);
+
+        for (int i = 0; i < QUERY_AMOUNT; i++) {
+            var stage = stages.get(i);
+            var stageTeamUuid = runFindTeamUuidByCaseAndStageQuery(stage.getCaseUUID(), stage.getUuid(), timings, i);
+
+            if (stage.getTeamUUID() == null) {
+                assertThat("No team uuid should return null", stageTeamUuid == null);
+            } else {
+                assertThat("Uuid should match the projection", stage.getTeamUUID().toString().equals(stageTeamUuid.getTeamUuid()));
+            }
+        }
+
+        for (int i = 0; i < QUERY_AMOUNT; i++) {
+            /*
+             * This is still not overly representative of current systems,
+             * QA with >70k stages, runs these queries at around 1ms.
+             * But this should show degradation if the query is changed.
+             */
+            assertThat("Duration must be less than 2 seconds", timings[i] <= 2000L);
+        }
+    }
+
+    private void runFindAllActiveByTeamUuidQuery(UUID team, long[] timings, int iteration) {
         long start = System.currentTimeMillis();
         stageRepository.findAllActiveByTeamUUID(team);
         long finish = System.currentTimeMillis();
         timings[iteration] = finish - start;
     }
 
+    private Stage.StageTeamUuid runFindTeamUuidByCaseAndStageQuery(UUID caseUuid, UUID stageUuid, long[] timings, int iteration) {
+        long start = System.currentTimeMillis();
+        var result = stageRepository.findTeamUuidByCaseUuidAndStageUuid(caseUuid, stageUuid);
+        long finish = System.currentTimeMillis();
+        timings[iteration] = finish - start;
+        return result;
+    }
 
     private void createLargeDataSet(int howManyCases) {
-
         UUID prevCaseUuid = null;
 
         // Add cases
@@ -81,13 +117,13 @@ public class StageRepositoryTest {
 
             if (i % 500 == 0) {
                 log.info("Added case:{}", i);
-
             }
 
             // add some stage data to parent case
             for (int y = 0; y < 10; y++) {
                 String stageType = "stage" + y;
                 Stage stage = new Stage(caseData.getUuid(), stageType, y == 5 ? TEAM_UUID : null, null, null);
+
                 entityManager.persist(stage);
                 log.debug("Added case: {}, stage: {}", caseData.getUuid(), stageType);
             }
@@ -103,5 +139,31 @@ public class StageRepositoryTest {
             }
 
         }
+    }
+
+    public List<Stage> createCaseWithStages(final int caseAmount) {
+        List<Stage> listAddedStages = new ArrayList<>();
+
+        // Add cases
+        for (int i = 0; i < caseAmount; i++) {
+            CaseData caseData = new CaseData(CaseDataTypeFactory.from("TEST", "a1"), (long) i, LocalDate.of(2000, 12, 31));
+            caseData.setCaseDeadline(LocalDate.of(9999, 12, 31));
+            entityManager.persist(caseData);
+
+            // add some stage data to parent case
+            for (int y = 0; y < 3; y++) {
+                String stageType = "stage" + y;
+                Stage stage = new Stage(caseData.getUuid(), stageType, y == 2 ? TEAM_UUID : null, null, null);
+
+                entityManager.persist(stage);
+
+                listAddedStages.add(stage);
+
+                log.debug("Added case: {}, stage: {}", caseData.getUuid(), stageType);
+            }
+        }
+
+        return listAddedStages;
+
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
@@ -25,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(SpringRunner.class)
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 public class StageRepositoryTest {
 
@@ -164,6 +166,5 @@ public class StageRepositoryTest {
         }
 
         return listAddedStages;
-
     }
 }


### PR DESCRIPTION
When trying to get the team uuid currently this queries the `stage_data`
 view that returns not only more information than required but also
 computes every join. As the required data is immediately
 available on the `stage` table, this can easily be retrieved through a
 projection, saving the computation time of the view.

During testing on QA with around 70k current stages, the old query returned
in 60ms (without load) whilst the new one was around 1ms (without load).