### PR TITLE
HOCS-3848: return FoI contributions

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspector.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspector.java
@@ -38,4 +38,17 @@ public class ContributionSomuInspector {
         String contributionDueDate = getContributionDueDate();
         return LocalDate.parse(contributionDueDate, dtf);
     }
+
+    public boolean isContribution() {
+        try {
+            /*
+             * Read method throws an exception if it does not find the item,
+             * all contributions have a 'contributionDueDate' at present.
+             */
+            ctx.read("$.contributionDueDate");
+            return true;
+        } catch(PathNotFoundException ex) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
@@ -29,7 +29,10 @@ public class ContributionsProcessorImpl implements ContributionsProcessor {
 
     @Override
     public void processContributionsForStage(Stage stage) {
-        if (MPAMContributionStages.contains(stage.getStageType()) || COMPLIANT_CASE_TYPE.equals(stage.getCaseDataType())) {
+        if (MPAMContributionStages.contains(stage.getStageType())
+                || FOIContributionStages.contains(stage.getStageType())
+                || COMPLIANT_CASE_TYPE.equals(stage.getCaseDataType())) {
+
             Set<SomuItem> contributionSomuItems = somuItemService.getCaseSomuItemsBySomuType(stage.getCaseUUID(), false);
             calculateDueContributionDate(contributionSomuItems)
                     .ifPresent(ld -> {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.digital.ho.hocs.casework.contributions.ContributionStatus.*;
@@ -34,6 +35,9 @@ public class ContributionsProcessorImpl implements ContributionsProcessor {
                 || COMPLIANT_CASE_TYPE.equals(stage.getCaseDataType())) {
 
             Set<SomuItem> contributionSomuItems = somuItemService.getCaseSomuItemsBySomuType(stage.getCaseUUID(), false);
+
+            contributionSomuItems = filterContributions(contributionSomuItems);
+
             calculateDueContributionDate(contributionSomuItems)
                     .ifPresent(ld -> {
                         log.info("Setting contribution date {}, for caseId {}", ld, stage.getCaseUUID());
@@ -78,5 +82,11 @@ public class ContributionsProcessorImpl implements ContributionsProcessor {
                     }
                 })
                 .max(Comparator.naturalOrder());
+    }
+
+    Set<SomuItem> filterContributions(Set<SomuItem> items) {
+        return items.stream()
+                .filter(item -> new ContributionSomuInspector(item).isContribution())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/FOIContributionStages.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/FOIContributionStages.java
@@ -1,0 +1,16 @@
+package uk.gov.digital.ho.hocs.casework.contributions;
+
+public enum FOIContributionStages {
+    // Requested stages
+    FOI_APPROVAL,
+    FOI_DRAFT;
+
+    public static boolean contains(String stage) {
+        for (FOIContributionStages c : FOIContributionStages.values()) {
+            if (c.name().equals(stage)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspectorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionSomuInspectorTest.java
@@ -52,5 +52,21 @@ public class ContributionSomuInspectorTest {
         ContributionSomuInspector somuInspector = new ContributionSomuInspector(somuItem);
         assertEquals(ContributionStatus.NONE, somuInspector.getContributionStatus());
     }
+
+    @Test
+    public void shouldReturnFalseIfNotContribution() {
+        String jsonString = "{}";
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, jsonString);
+        ContributionSomuInspector somuInspector = new ContributionSomuInspector(somuItem);
+        assertFalse(somuInspector.isContribution());
+    }
+
+    @Test
+    public void shouldReturnTrueIfContribution() {
+        String jsonString = "{ \"contributionDueDate\" : \"2020-10-10\"}";
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, jsonString);
+        ContributionSomuInspector somuInspector = new ContributionSomuInspector(somuItem);
+        assertTrue(somuInspector.isContribution());
+    }
     
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
@@ -187,4 +187,31 @@ public class ContributionsProcessorTest {
         ContributionStatus contributionStatus = contributionsProcessor.highestContributionStatus(Set.of(somuItem), LocalDate.of(2020, 10, 10)).orElse(null);
         assertEquals(ContributionStatus.CONTRIBUTION_DUE, contributionStatus);
     }
+
+    @Test
+    public void shouldReturnFilteredSomuItems() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"TEST\" : \"2020-11-10\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributions(Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),1);
+        assertTrue(contributions.contains(somuItem1));
+    }
+
+    @Test
+    public void shouldReturnFilteredSomuItems_noContributions() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"TEST\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"TEST\" : \"2020-11-10\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributions(Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),0);
+    }
+
+    @Test
+    public void shouldReturnFilteredSomuItems_allContributions() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-11\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributions(Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),2);
+        assertTrue(contributions.contains(somuItem1));
+        assertTrue(contributions.contains(somuItem2));
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
@@ -96,6 +96,36 @@ public class ContributionsProcessorTest {
     }
 
     @Test
+    public void shouldAddOverdueContributionsForFOICase() {
+        String stageType = "FOI_APPROVAL";
+        Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
+        doReturn("FOI_APPROVAL").when(stage).getStageType();
+
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-10-10\"}");
+
+        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+
+        contributionsProcessor.processContributionsForStage(stage);
+        assertEquals("2020-10-10", stage.getDueContribution());
+        assertEquals("Overdue", stage.getContributions());
+    }
+
+    @Test
+    public void shouldAddDueContributionsForFOICase() {
+        String stageType = "FOI_APPROVAL";
+        Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
+        doReturn("FOI_APPROVAL").when(stage).getStageType();
+
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
+
+        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+
+        contributionsProcessor.processContributionsForStage(stage);
+        assertEquals("9999-10-10", stage.getDueContribution());
+        assertEquals("Due", stage.getContributions());
+    }
+
+    @Test
     public void shouldCalculateDueContribution() {
         SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-10-10\"}");
         SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-09-10\"}");


### PR DESCRIPTION
This change re-works adds in FoI contributions into the ContributionsProcessor so that it is returned neatly as part of the stage object. 

As a result of there being a SOMU Type that is not a contributions a filtering has been applied to remove the non-contributions.