### PR TITLE
HOCS-3979: contribution processor improvements

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResource.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
@@ -27,28 +27,28 @@ public class SomuItemResource {
     }
 
     @Authorised (accessLevel = AccessLevel.READ)
-    @GetMapping(value = "/case/{caseUuid}/item", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/{caseUuid}/item", produces = APPLICATION_JSON_VALUE)
     ResponseEntity<Set<GetSomuItemResponse>> getAllCaseSomuItems(@PathVariable UUID caseUuid) {
-        Set<SomuItem> somuItems = somuItemService.getCaseSomuItemsBySomuType(caseUuid, true);
+        Set<SomuItem> somuItems = somuItemService.getItemsByCaseUuid(caseUuid);
         return ResponseEntity.ok(somuItems.stream().map(GetSomuItemResponse::from).collect(Collectors.toSet()));
     }
 
     @Authorised (accessLevel = AccessLevel.READ)
-    @GetMapping(value = "/case/{caseUuid}/item/{somuTypeUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/{caseUuid}/item/{somuTypeUuid}", produces = APPLICATION_JSON_VALUE)
     ResponseEntity<Set<GetSomuItemResponse>> getCaseSomuItemsBySomuType(@PathVariable UUID caseUuid, @PathVariable UUID somuTypeUuid) {
-        Set<SomuItem> somuItems = somuItemService.getCaseSomuItemsBySomuType(caseUuid, somuTypeUuid);
+        Set<SomuItem> somuItems = somuItemService.getItemsByCaseUuidAndType(caseUuid, somuTypeUuid);
         return ResponseEntity.ok(somuItems.stream().map(GetSomuItemResponse::from).collect(Collectors.toSet()));
     }
 
     @Authorised(accessLevel = AccessLevel.WRITE)
     @DeleteMapping(value = "/item/{somuUuid}")
-    ResponseEntity deleteSomuItem(@PathVariable UUID somuUuid) {
+    ResponseEntity<Void> deleteSomuItem(@PathVariable UUID somuUuid) {
         somuItemService.deleteSomuItem(somuUuid);
         return ResponseEntity.ok().build();
     }
 
     @Authorised(accessLevel = AccessLevel.WRITE)
-    @PostMapping(value = "/case/{caseUuid}/item/{somuTypeUuid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/case/{caseUuid}/item/{somuTypeUuid}", produces = APPLICATION_JSON_VALUE)
     ResponseEntity<GetSomuItemResponse> upsertCaseSomuItemBySomuType(@PathVariable UUID caseUuid, @PathVariable UUID somuTypeUuid, @RequestBody CreateSomuItemRequest data) {
         SomuItem somuItem = somuItemService.upsertCaseSomuItemBySomuType(caseUuid, somuTypeUuid, data);
         return ResponseEntity.ok(GetSomuItemResponse.from(somuItem));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
@@ -30,17 +30,26 @@ public class SomuItemService {
         this.auditClient = auditClient;
     }
 
-    public Set<SomuItem> getCaseSomuItemsBySomuType(UUID caseUUID, boolean audit) {
-        log.debug("Getting all Somu Items for Case: {}", caseUUID);
-        Set<SomuItem> somuItems = somuItemRepository.findAllByCaseUuid(caseUUID);
-        log.info("Got {} Somu Item for Case: {}, Event {}", somuItems.size(), caseUUID, value(EVENT, SOMU_ITEM_RETRIEVED));
-        if(audit){
-            auditClient.viewAllSomuItemsAudit(caseUUID);
-        }
+    public Set<SomuItem> getCaseItemsByCaseUuids(Set<UUID> caseUuids) {
+        log.debug("Getting all Somu Items for Case: {}", caseUuids);
+        Set<SomuItem> somuItems = somuItemRepository.findAllByCaseUuidIn(caseUuids);
+        log.info("Got {} Somu Item for Case: {}, Event {}", somuItems.size(), caseUuids, value(EVENT, SOMU_ITEM_RETRIEVED));
+
+        auditClient.viewAllSomuItemsForCasesAudit(caseUuids);
+
         return somuItems;
     }
 
-    public Set<SomuItem> getCaseSomuItemsBySomuType(UUID caseUuid, UUID somuTypeUuid) {
+    public Set<SomuItem> getItemsByCaseUuid(UUID caseUUID) {
+        log.debug("Getting all Somu Items for Case: {}", caseUUID);
+        Set<SomuItem> somuItems = somuItemRepository.findAllByCaseUuid(caseUUID);
+        log.info("Got {} Somu Item for Case: {}, Event {}", somuItems.size(), caseUUID, value(EVENT, SOMU_ITEM_RETRIEVED));
+        auditClient.viewAllSomuItemsAudit(caseUUID);
+
+        return somuItems;
+    }
+
+    public Set<SomuItem> getItemsByCaseUuidAndType(UUID caseUuid, UUID somuTypeUuid) {
         Set<SomuItem> somuItems = somuItemRepository.findByCaseUuidAndSomuUuid(caseUuid, somuTypeUuid);
         
         log.info("Got SomuItems for UUID: {}, Event {}", somuTypeUuid, value(EVENT, SOMU_ITEM_RETRIEVED));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -255,9 +255,9 @@ public class StageService {
         return stages;
     }
 
-    void updateContributions(Stage stage) {
-        log.debug("Adding contributions data for stage : {}", stage.getCaseUUID());
-        contributionsProcessor.processContributionsForStage(stage);
+    void updateContributions(Set<Stage> stage) {
+        log.debug("Adding contributions data for stages");
+        contributionsProcessor.processContributionsForStages(stage);
     }
 
     Stage getUnassignedAndActiveStageByTeamUUID(UUID teamUUID, UUID userUUID) {
@@ -335,9 +335,9 @@ public class StageService {
     }
 
     private void updateStages(Set<Stage> stages) {
-        auditClient.viewAllSomuItemsAudit(null);
+        updateContributions(stages);
+
         for (Stage stage : stages) {
-            updateContributions(stage);
             updatePriority(stage);
             updateDaysElapsed(stage);
             decorateTags(stage);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.ProducerTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import uk.gov.digital.ho.hocs.casework.application.RequestData;
@@ -482,7 +480,6 @@ public class AuditClient {
         sendAuditMessage(localDateTime, caseUUID, payload, eventType, stageUUID, "{}", correlationId, userId, username, groups);
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     private void sendAuditMessage(LocalDateTime localDateTime, UUID caseUUID, String payload, EventType eventType, UUID stageUUID, String data, String correlationId, String userId, String username, String groups) {
         CreateAuditRequest request = new CreateAuditRequest(
                 correlationId,

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -239,6 +239,23 @@ public class AuditClient {
                 requestDataDto.getUserId(), requestDataDto.getUsername(), requestDataDto.getGroups()));
     }
 
+    public void viewAllSomuItemsForCasesAudit(Set<UUID> caseUuids) {
+        RequestDataDto requestDataDto = RequestDataDto.from(requestData);
+        LocalDateTime localDateTime = LocalDateTime.now();
+
+        executorService.execute(() -> {
+            String data = "{}";
+            try {
+                data = objectMapper.writeValueAsString(caseUuids);
+            } catch (JsonProcessingException e) {
+                logFailedToParseDataPayload(e);
+            }
+
+            sendAuditMessage(localDateTime, null, data, EventType.SOMU_ITEMS_VIEWED, null, requestDataDto.getCorrelationId(),
+                    requestDataDto.getUserId(), requestDataDto.getUsername(), requestDataDto.getGroups());
+        });
+    }
+
     public void viewCaseSomuItemsBySomuTypeAudit(UUID caseUUID, UUID somuTypeUUID) {
         RequestDataDto requestDataDto = RequestDataDto.from(requestData);
         LocalDateTime localDateTime = LocalDateTime.now();

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
@@ -2,6 +2,8 @@ package uk.gov.digital.ho.hocs.casework.contributions;
 
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 
+import java.util.Set;
+
 public interface ContributionsProcessor {
-    void processContributionsForStage(Stage stage);
+    void processContributionsForStages(Set<Stage> stage);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SomuItemRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SomuItemRepository.java
@@ -14,6 +14,8 @@ public interface SomuItemRepository extends CrudRepository<SomuItem, Long> {
 
     Set<SomuItem> findAllByCaseUuid(UUID caseUuid);
 
+    Set<SomuItem> findAllByCaseUuidIn(Set<UUID> caseUuids);
+
     Set<SomuItem> findByCaseUuidAndSomuUuid(UUID caseUuid, UUID somuUuid);
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemResourceTest.java
@@ -44,7 +44,7 @@ public class SomuItemResourceTest {
 
         ResponseEntity<GetSomuItemResponse> response = somuItemResource.upsertCaseSomuItemBySomuType(caseUUID, somuUUID, somuItemRequest);
 
-        verify(somuItemService, times(1)).upsertCaseSomuItemBySomuType(caseUUID, somuUUID, somuItemRequest);
+        verify(somuItemService).upsertCaseSomuItemBySomuType(caseUUID, somuUUID, somuItemRequest);
 
         checkNoMoreInteractions();
 
@@ -57,9 +57,9 @@ public class SomuItemResourceTest {
     
     @Test
     public void shouldDeleteSomuItem() {
-        ResponseEntity response = somuItemResource.deleteSomuItem(uuid);
+        ResponseEntity<Void> response = somuItemResource.deleteSomuItem(uuid);
 
-        verify(somuItemService, times(1)).deleteSomuItem(uuid);
+        verify(somuItemService).deleteSomuItem(uuid);
 
         checkNoMoreInteractions();
 
@@ -71,11 +71,11 @@ public class SomuItemResourceTest {
     public void shouldGetSomuItems() {
         SomuItem somuItem = new SomuItem(uuid, caseUUID, somuUUID, "{}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, true)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getItemsByCaseUuid(caseUUID)).thenReturn(Set.of(somuItem));
 
         ResponseEntity<Set<GetSomuItemResponse>> response = somuItemResource.getAllCaseSomuItems(caseUUID);
 
-        verify(somuItemService, times(1)).getCaseSomuItemsBySomuType(caseUUID, true);
+        verify(somuItemService).getItemsByCaseUuid(caseUUID);
 
         checkNoMoreInteractions();
 
@@ -89,11 +89,11 @@ public class SomuItemResourceTest {
     public void shouldGetSomuItem() {
         SomuItem somuItem = new SomuItem(uuid, caseUUID, somuUUID, "{}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, somuUUID)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getItemsByCaseUuidAndType(caseUUID, somuUUID)).thenReturn(Set.of(somuItem));
 
         ResponseEntity<Set<GetSomuItemResponse>> response = somuItemResource.getCaseSomuItemsBySomuType(caseUUID, somuUUID);
 
-        verify(somuItemService, times(1)).getCaseSomuItemsBySomuType(caseUUID, somuUUID);
+        verify(somuItemService).getItemsByCaseUuidAndType(caseUUID, somuUUID);
 
         checkNoMoreInteractions();
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/SomuItemServiceTest.java
@@ -44,7 +44,7 @@ public class SomuItemServiceTest {
         
         when(somuItemRepository.findAllByCaseUuid(any())).thenReturn(Set.of(somuItem));
         
-        somuItemService.getCaseSomuItemsBySomuType(caseUuid, true);
+        somuItemService.getItemsByCaseUuid(caseUuid);
 
         verify(somuItemRepository, times(1)).findAllByCaseUuid(caseUuid);
         verify(auditClient, times(1)).viewAllSomuItemsAudit(caseUuid);
@@ -57,7 +57,7 @@ public class SomuItemServiceTest {
 
         when(somuItemRepository.findByCaseUuidAndSomuUuid(any(), any())).thenReturn(Set.of(somuItem));
 
-        somuItemService.getCaseSomuItemsBySomuType(caseUuid, somuTypeUuid);
+        somuItemService.getItemsByCaseUuidAndType(caseUuid, somuTypeUuid);
 
         verify(somuItemRepository, times(1)).findByCaseUuidAndSomuUuid(caseUuid, somuTypeUuid);
         verify(auditClient, times(1)).viewCaseSomuItemsBySomuTypeAudit(caseUuid, somuTypeUuid);
@@ -68,7 +68,7 @@ public class SomuItemServiceTest {
     public void shouldGetSomuItem_EmptySetReturnedWhenNoneExist() throws ApplicationExceptions.EntityNotFoundException {
         when(somuItemRepository.findByCaseUuidAndSomuUuid(any(), any())).thenReturn(Collections.emptySet());
 
-        Set<SomuItem> somuItem = somuItemService.getCaseSomuItemsBySomuType(caseUuid, somuTypeUuid);
+        Set<SomuItem> somuItem = somuItemService.getItemsByCaseUuidAndType(caseUuid, somuTypeUuid);
 
         verify(somuItemRepository, times(1)).findByCaseUuidAndSomuUuid(caseUuid, somuTypeUuid);
         verify(auditClient, times(1)).viewCaseSomuItemsBySomuTypeAudit(caseUuid, somuTypeUuid);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -353,7 +353,6 @@ public class StageServiceTest {
         verify(stageRepository).findAllActiveByTeamUUIDAndCaseType(teams, caseTypes);
         verify(stagePriorityCalculator).updatePriority(stage);
         verify(daysElapsedCalculator).updateDaysElapsed(stage);
-        verify(auditClient).viewAllSomuItemsAudit(null);
 
         checkNoMoreInteraction();
     }
@@ -778,11 +777,14 @@ public class StageServiceTest {
     }
 
     @Test
-    public void shouldGetActiveStagesByTeamUUID() {
-        Stage stage = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
-        when(stageRepository.findAllActiveByTeamUUID(teamUUID)).thenReturn(Set.of(stage));
+    public void shouldGetActiveStagesByTeamUuids() {
+        Stage stage1 = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Stage stage2 = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Set<Stage> stages = Set.of(stage1, stage2);
+
+        when(stageRepository.findAllActiveByTeamUUID(teamUUID)).thenReturn(stages);
         stageService.getActiveStagesByTeamUUID(teamUUID);
-        verify(contributionsProcessor).processContributionsForStage(stage);
+        verify(contributionsProcessor).processContributionsForStages(stages);
     }
 
     @Test
@@ -803,7 +805,6 @@ public class StageServiceTest {
         verify(stageRepository).findAllActiveByUserUuidAndTeamUuidAndCaseType(userUUID, teams, caseTypes);
         verify(stagePriorityCalculator).updatePriority(stage);
         verify(daysElapsedCalculator).updateDaysElapsed(stage);
-        verify(auditClient).viewAllSomuItemsAudit(null);
 
         checkNoMoreInteraction();
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
@@ -36,6 +36,38 @@ public class ContributionsProcessorTest {
     }
 
     @Test
+    public void shouldReturnWithSomuItemsProvided() {
+        var spiedContributionsProcessor = spy(contributionsProcessor);
+
+        Stage stage = spy(new Stage(caseUUID, "ANY", teamUUID, userUUID, transitionNoteUUID));
+
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Collections.emptySet());
+
+        spiedContributionsProcessor.processContributionsForStages(Set.of(stage));
+
+        verify(spiedContributionsProcessor).processContributionsForStages(Set.of(stage));
+        verify(somuItemService).getCaseItemsByCaseUuids(Set.of(caseUUID));
+        verifyNoMoreInteractions(spiedContributionsProcessor, somuItemService);
+    }
+
+    @Test
+    public void shouldReturnWithNoContributionsProvided() {
+        var spiedContributionsProcessor = spy(contributionsProcessor);
+
+        Stage stage = spy(new Stage(caseUUID, "ANY", teamUUID, userUUID, transitionNoteUUID));
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"TEST\" : \"TEST\"}");
+
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
+
+        spiedContributionsProcessor.processContributionsForStages(Set.of(stage));
+
+        verify(spiedContributionsProcessor).processContributionsForStages(Set.of(stage));
+        verify(somuItemService).getCaseItemsByCaseUuids(Set.of(caseUUID));
+        verify(spiedContributionsProcessor).filterContributions(Set.of(somuItem));
+        verifyNoMoreInteractions(spiedContributionsProcessor, somuItemService);
+    }
+
+    @Test
     public void shouldAddOverdueContributionsForCompCase() {
         String stageType = "COMP";
         Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
@@ -43,9 +75,9 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("2020-10-10", stage.getDueContribution());
         assertEquals("Overdue", stage.getContributions());
     }
@@ -58,9 +90,9 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("9999-10-10", stage.getDueContribution());
         assertEquals("Due", stage.getContributions());
     }
@@ -73,9 +105,9 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("2020-10-10", stage.getDueContribution());
         assertEquals("Overdue", stage.getContributions());
     }
@@ -88,9 +120,9 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("9999-10-10", stage.getDueContribution());
         assertEquals("Due", stage.getContributions());
     }
@@ -103,9 +135,9 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("2020-10-10", stage.getDueContribution());
         assertEquals("Overdue", stage.getContributions());
     }
@@ -118,11 +150,28 @@ public class ContributionsProcessorTest {
 
         SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
 
-        when(somuItemService.getCaseSomuItemsBySomuType(caseUUID, false)).thenReturn(Set.of(somuItem));
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
 
-        contributionsProcessor.processContributionsForStage(stage);
+        contributionsProcessor.processContributionsForStages(Set.of(stage));
         assertEquals("9999-10-10", stage.getDueContribution());
         assertEquals("Due", stage.getContributions());
+    }
+
+    @Test
+    public void shouldNotActionIfStageDoesNotMatchRequired() {
+        String stageType = "TEST";
+        Stage stage = spy(new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID));
+        doReturn("TEST").when(stage).getStageType();
+
+        SomuItem somuItem = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"9999-10-10\"}");
+
+        when(somuItemService.getCaseItemsByCaseUuids(Set.of(caseUUID))).thenReturn(Set.of(somuItem));
+
+        Set<Stage> preTest = Set.of(stage);
+
+        contributionsProcessor.processContributionsForStages(preTest);
+
+        assertEquals(preTest, Set.of(stage));
     }
 
     @Test
@@ -207,6 +256,33 @@ public class ContributionsProcessorTest {
 
     @Test
     public void shouldReturnFilteredSomuItems_allContributions() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-11\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributions(Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),2);
+        assertTrue(contributions.contains(somuItem1));
+        assertTrue(contributions.contains(somuItem2));
+    }
+
+    @Test
+    public void shouldReturnFilteredSomuItemsByCase() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, UUID.randomUUID(), somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributionsByCase(caseUUID, Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),1);
+        assertTrue(contributions.contains(somuItem1));
+    }
+
+    @Test
+    public void shouldReturnFilteredSomuItemsByCase_noContributions() {
+        SomuItem somuItem1 = new SomuItem(somuUUID, UUID.randomUUID(), somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        SomuItem somuItem2 = new SomuItem(somuUUID, UUID.randomUUID(), somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
+        Set<SomuItem> contributions = contributionsProcessor.filterContributionsByCase(caseUUID, Set.of(somuItem1, somuItem2));
+        assertEquals(contributions.size(),0);
+    }
+
+    @Test
+    public void shouldReturnFilteredSomuItemsByCase_allContributions() {
         SomuItem somuItem1 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-10\"}");
         SomuItem somuItem2 = new SomuItem(somuUUID, caseUUID, somuTypeUuid, "{ \"contributionDueDate\" : \"2020-11-11\"}");
         Set<SomuItem> contributions = contributionsProcessor.filterContributions(Set.of(somuItem1, somuItem2));

--- a/src/test/resources/stage/afterTest.sql
+++ b/src/test/resources/stage/afterTest.sql
@@ -1,0 +1,3 @@
+DELETE FROM casework.case_link WHERE TRUE;
+DELETE FROM casework.stage WHERE TRUE;
+DELETE FROM casework.case_data WHERE TRUE;


### PR DESCRIPTION
Presently, when a workstack is loaded, a call is made for each 'stage'
is part of that workstack to retrieve the contributions. This is causing
potentially thousands of calls and taking more resources than necessary
This change requests all the contributions for all the stages at once,
leading to only one hit on the database.

A side effect of this is we can revert the auditing code that was
applied previously.