### PR TITLE
HOCS-4073: use multi-stage docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/alpine:v3.13 as builder
+FROM quay.io/ukhomeofficedigital/alpine:v3.14 as builder
 
 USER root
 
@@ -8,7 +8,7 @@ COPY build/libs/*.jar .
 
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM quay.io/ukhomeofficedigital/alpine:v3.13
+FROM quay.io/ukhomeofficedigital/alpine:v3.14
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
-FROM quay.io/ukhomeofficedigital/alpine:v3.13
-
-ENV USER user_hocs_casework
-ENV USER_ID 1000
-ENV GROUP group_hocs_casework
-ENV NAME hocs-casework
-ENV JAR_PATH build/libs
+FROM quay.io/ukhomeofficedigital/alpine:v3.13 as builder
 
 USER root
 
-RUN apk add openjdk11-jre
+RUN apk add --no-cache openjdk11-jre
+
+COPY build/libs/*.jar .
+
+RUN java -Djarmode=layertools -jar *.jar extract
+
+FROM quay.io/ukhomeofficedigital/alpine:v3.13
+
+USER root
+
+RUN apk add --no-cache openjdk11-jre
 
 WORKDIR /app
+
+ENV USER user_hocs
+ENV USER_ID 1000
+ENV GROUP group_hocs
 
 RUN addgroup -S ${GROUP} && \
     adduser -S -u ${USER_ID} ${USER} -G ${GROUP} -h /app && \
     mkdir -p /app && \
     chown -R ${USER}:${GROUP} /app
 
-COPY ${JAR_PATH}/${NAME}*.jar /app
-
-ADD scripts /app/scripts
+COPY scripts/run.sh /app/scripts/run.sh
 
 RUN chmod a+x /app/scripts/*
+
+COPY --from=builder dependencies/ ./
+COPY --from=builder snapshot-dependencies/ ./
+RUN true # Bug where copying with 0 action then copying again throws an error
+COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder application/ ./
 
 EXPOSE 8080
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,5 +2,4 @@
 
 NAME=${NAME:-casework}
 
-JAR=$(find . -name ${NAME}*.jar|head -1)
-exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"
+exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom org.springframework.boot.loader.JarLauncher

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-NAME=${NAME:-casework}
-
 exec java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
This commit moves us to a multi-stage docker build with a layered jar instead of a fat jar. The objective is to reduce the springboot startup time in k8s environments, a side effect is more efficent docker layer caching for developer flow.

This change in isolation reduces the Startup time in k8s from 
Started HocsCaseApplication in 24.14 seconds (JVM running for 25.76)
to
Started HocsCaseApplication in 10.893 seconds (JVM running for 11.479)