### PR TITLE
HOCS-4045: update log line

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
@@ -32,8 +32,9 @@ public class SomuItemService {
 
     public Set<SomuItem> getCaseItemsByCaseUuids(Set<UUID> caseUuids) {
         log.debug("Getting all Somu Items for Case: {}", caseUuids);
+
         Set<SomuItem> somuItems = somuItemRepository.findAllByCaseUuidIn(caseUuids);
-        log.info("Got {} Somu Item for Case: {}, Event {}", somuItems.size(), caseUuids, value(EVENT, SOMU_ITEM_RETRIEVED));
+        log.info("Got {} Somu Item for {} cases, Event {}", somuItems.size(), caseUuids.size(), value(EVENT, SOMU_ITEM_RETRIEVED));
 
         auditClient.viewAllSomuItemsForCasesAudit(caseUuids);
 


### PR DESCRIPTION
Currently, we are printing out all the case uuids that we are
requesting the somu items for in the SomuItemService. This is causing
extremely long logs in production that get split over multiple lines
every time a call to the callee happens. This is a change to the log
line to print out the number of cases that and somu items that have been
 retreived as printing potentially thousands of uuids isn't particulary
 useful.