### PR TITLE
HOCS-4235: Reduce stage/user/userid endpoint response time

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -46,7 +46,7 @@ public interface StageRepository extends CrudRepository<BaseStage, Long> {
     @Query(value = "SELECT * FROM active_stage_data sd WHERE sd.team_uuid IN ?1 OR sd.case_type IN ?2", nativeQuery = true)
     Set<StageWithCaseData> findAllActiveByTeamUUIDAndCaseType(Set<UUID> teamUUID, Set<String> caseTypes);
 
-    @Query(value = "SELECT * FROM active_stage_data sd WHERE user_uuid = ?1 AND data->>'Unworkable' != 'True' AND (sd.team_uuid IN ?2 OR sd.case_type IN ?3)", nativeQuery = true)
+    @Query(value = "SELECT * FROM active_stage_data sd WHERE user_uuid = ?1 AND ((data->>'Unworkable') IS NULL OR (data->>'Unworkable') <> 'True') AND (sd.team_uuid IN ?2 OR sd.case_type IN ?3)", nativeQuery = true)
     Set<StageWithCaseData> findAllActiveByUserUuidAndTeamUuidAndCaseType(UUID userUuid, Set<UUID> teamUUID, Set<String> caseTypes);
 
     @Query(value = "SELECT * FROM active_stage_data", nativeQuery = true)

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -46,7 +46,7 @@ public interface StageRepository extends CrudRepository<BaseStage, Long> {
     @Query(value = "SELECT * FROM active_stage_data sd WHERE sd.team_uuid IN ?1 OR sd.case_type IN ?2", nativeQuery = true)
     Set<StageWithCaseData> findAllActiveByTeamUUIDAndCaseType(Set<UUID> teamUUID, Set<String> caseTypes);
 
-    @Query(value = "SELECT * FROM active_stage_data sd WHERE user_uuid = ?1 AND NOT data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) AND (sd.team_uuid IN ?2 OR sd.case_type IN ?3)", nativeQuery = true)
+    @Query(value = "SELECT * FROM active_stage_data sd WHERE user_uuid = ?1 AND data->>'Unworkable' != 'True' AND (sd.team_uuid IN ?2 OR sd.case_type IN ?3)", nativeQuery = true)
     Set<StageWithCaseData> findAllActiveByUserUuidAndTeamUuidAndCaseType(UUID userUuid, Set<UUID> teamUUID, Set<String> caseTypes);
 
     @Query(value = "SELECT * FROM active_stage_data", nativeQuery = true)

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SummaryRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SummaryRepository.java
@@ -21,7 +21,7 @@ public class SummaryRepository {
     private EntityManager entityManager;
 
     public List<Summary> findTeamsAndCaseCountByTeamUuidandCaseTypes(Set<UUID> teamUuidSet, Set<String> caseTypeSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, count(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE NOT cd.deleted AND st.team_uuid IS NOT NULL AND (st.team_uuid IN ?1 OR cd.type IN ?2) AND NOT cd.data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, count(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE NOT cd.deleted AND st.team_uuid IS NOT NULL AND (st.team_uuid IN ?1 OR cd.type IN ?2) AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, caseTypeSet);
 
@@ -35,7 +35,7 @@ public class SummaryRepository {
     };
 
     public List<Summary> findUnallocatedCasesByTeam(Set<UUID> teamUuidSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid IS NULL AND NOT cd.data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid IS NULL AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
 
         query.unwrap(NativeQuery.class)
@@ -48,7 +48,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findOverdueCasesByTeam(Set<UUID> teamUuidSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid IN ?1 AND st.deadline < CURRENT_DATE AND NOT cd.data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid IN ?1 AND st.deadline < CURRENT_DATE AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
 
         query.unwrap(NativeQuery.class)
@@ -61,7 +61,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findOverdueUserCasesInTeams(Set<UUID> teamUuidSet, String userUuid) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND st.deadline < CURRENT_DATE AND NOT cd.data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND st.deadline < CURRENT_DATE AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, userUuid);
 
@@ -76,7 +76,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findUserCasesInTeams(Set<UUID> teamUuidSet, String userUuid) {
-        Query query = entityManager.createNativeQuery("SELECT CAST(st.team_uuid as varchar) as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND NOT cd.data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT CAST(st.team_uuid as varchar) as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, userUuid);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SummaryRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/SummaryRepository.java
@@ -21,7 +21,7 @@ public class SummaryRepository {
     private EntityManager entityManager;
 
     public List<Summary> findTeamsAndCaseCountByTeamUuidandCaseTypes(Set<UUID> teamUuidSet, Set<String> caseTypeSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, count(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE NOT cd.deleted AND st.team_uuid IS NOT NULL AND (st.team_uuid IN ?1 OR cd.type IN ?2) AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, count(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE NOT cd.deleted AND st.team_uuid IS NOT NULL AND (st.team_uuid IN ?1 OR cd.type IN ?2) AND ((cd.data->>'Unworkable') IS NULL OR (cd.data->>'Unworkable') <> 'True') GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, caseTypeSet);
 
@@ -35,7 +35,7 @@ public class SummaryRepository {
     };
 
     public List<Summary> findUnallocatedCasesByTeam(Set<UUID> teamUuidSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid IS NULL AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid IS NULL AND ((cd.data->>'Unworkable') IS NULL OR (cd.data->>'Unworkable') <> 'True') GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
 
         query.unwrap(NativeQuery.class)
@@ -48,7 +48,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findOverdueCasesByTeam(Set<UUID> teamUuidSet) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid IN ?1 AND st.deadline < CURRENT_DATE AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid IN ?1 AND st.deadline < CURRENT_DATE AND ((cd.data->>'Unworkable') IS NULL OR (cd.data->>'Unworkable') <> 'True') GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
 
         query.unwrap(NativeQuery.class)
@@ -61,7 +61,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findOverdueUserCasesInTeams(Set<UUID> teamUuidSet, String userUuid) {
-        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND st.deadline < CURRENT_DATE AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT st.team_uuid as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND st.deadline < CURRENT_DATE AND ((cd.data->>'Unworkable') IS NULL OR (cd.data->>'Unworkable') <> 'True') GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, userUuid);
 
@@ -76,7 +76,7 @@ public class SummaryRepository {
     }
 
     public List<Summary> findUserCasesInTeams(Set<UUID> teamUuidSet, String userUuid) {
-        Query query = entityManager.createNativeQuery("SELECT CAST(st.team_uuid as varchar) as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND cd.data->>'Unworkable' != 'True' GROUP BY st.team_uuid");
+        Query query = entityManager.createNativeQuery("SELECT CAST(st.team_uuid as varchar) as teamUuid, COUNT(*) FROM casework.stage st INNER JOIN casework.case_data cd ON st.case_uuid = cd.uuid WHERE st.team_uuid in ?1 AND st.user_uuid = ?2 AND ((cd.data->>'Unworkable') IS NULL OR (cd.data->>'Unworkable') <> 'True') GROUP BY st.team_uuid");
         query.setParameter(1, teamUuidSet);
         query.setParameter(2, userUuid);
 

--- a/src/main/resources/db/migration/postgresql/V1_35__4235_ADD_UNWORKABLE_INDEX.sql
+++ b/src/main/resources/db/migration/postgresql/V1_35__4235_ADD_UNWORKABLE_INDEX.sql
@@ -1,0 +1,3 @@
+SET search_path TO casework;
+
+CREATE INDEX IF NOT EXISTS ixd_case_data_json ON case_data ((data->>'Unworkable'));


### PR DESCRIPTION
This commit modifies the WHERE clause on 'User Workstack' query to remove the CAST from the jsonB clause and adds an index.

This change reduces the query execution time as follows:

Before:
 Planning time: 1.666 ms
 Execution time: 7867.209 ms

After:
 Planning time: 1.657 ms
 Execution time: 420.508 ms