### PR TITLE
Hocs-4235 -'updateStageCurrentTransitionNote' is using a slow query

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -164,7 +164,7 @@ public class StageService {
             }
         }
 
-        stage.setUser(userUUID);
+        stage.setUserUUID(userUUID);
         stageRepository.save(stage);
         auditClient.createStage(stage);
         updateCurrentStageForCase(caseUUID, stage.getUuid(), stageType);
@@ -184,7 +184,7 @@ public class StageService {
     void updateStageCurrentTransitionNote(UUID caseUUID, UUID stageUUID, UUID transitionNoteUUID) {
         log.debug("Updating Transition Note for Stage: {}", stageUUID);
         Stage stage = getActiveBasicStage(caseUUID, stageUUID);
-        stage.setTransitionNote(transitionNoteUUID);
+        stage.setTransitionNoteUUID(transitionNoteUUID);
         stageRepository.save(stage);
         log.info("Set Stage Transition Note: {} ({}) for Case {}", stageUUID, transitionNoteUUID, caseUUID, value(EVENT, STAGE_TRANSITION_NOTE_UPDATED));
     }
@@ -248,7 +248,7 @@ public class StageService {
         log.debug("Updating User: {} for Stage: {}", newUserUUID, stageUUID);
         StageWithCaseData stage = getActiveStage(caseUUID, stageUUID);
         UUID currentUserUUID = stage.getUserUUID();
-        stage.setUser(newUserUUID);
+        stage.setUserUUID(newUserUUID);
         stageRepository.save(stage);
         auditClient.updateStageUser(stage);
         log.info("Updated User: {} for Stage {}", newUserUUID, stageUUID, value(EVENT, STAGE_ASSIGNED_USER));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -183,7 +183,7 @@ public class StageService {
 
     void updateStageCurrentTransitionNote(UUID caseUUID, UUID stageUUID, UUID transitionNoteUUID) {
         log.debug("Updating Transition Note for Stage: {}", stageUUID);
-        StageWithCaseData stage = getActiveStage(caseUUID, stageUUID);
+        Stage stage = getActiveBasicStage(caseUUID, stageUUID);
         stage.setTransitionNote(transitionNoteUUID);
         stageRepository.save(stage);
         log.info("Set Stage Transition Note: {} ({}) for Case {}", stageUUID, transitionNoteUUID, caseUUID, value(EVENT, STAGE_TRANSITION_NOTE_UPDATED));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
@@ -72,14 +72,6 @@ public abstract class BaseStage implements Serializable {
         this.userUUID = null;
     }
 
-    public void setUser(UUID userUUID) {
-        this.userUUID = userUUID;
-    }
-
-    public void setTransitionNote(UUID transitionNoteUUID) {
-        this.transitionNoteUUID = transitionNoteUUID;
-    }
-
     public boolean isActive() {
         return this.teamUUID != null;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
@@ -72,6 +72,14 @@ public abstract class BaseStage implements Serializable {
         this.userUUID = null;
     }
 
+    public void setUser(UUID userUUID) {
+        this.userUUID = userUUID;
+    }
+
+    public void setTransitionNote(UUID transitionNoteUUID) {
+        this.transitionNoteUUID = transitionNoteUUID;
+    }
+
     public boolean isActive() {
         return this.teamUUID != null;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
@@ -62,6 +62,7 @@ public class StageWithCaseData extends BaseStage {
     private String correspondents;
 
     @Getter
+    @Setter
     @Column(name = "case_assigned_topic", insertable = false, updatable = false)
     private String assignedTopic;
 
@@ -124,25 +125,9 @@ public class StageWithCaseData extends BaseStage {
         this.caseUUID = caseUUID;
         this.stageType = stageType;
         this.transitionNoteUUID = transitionNoteUUID;
-        completed = Boolean.FALSE;
+        this.completed = Boolean.FALSE;
         setTeam(teamUUID);
-        setUser(userUUID);
-    }
-
-    public void setDeadline(LocalDate deadline) {
-        this.deadline = deadline;
-    }
-
-    public void setDeadlineWarning(LocalDate deadlineWarning){
-        this.deadlineWarning = deadlineWarning;
-    }
-
-    public void setAssignedTopic(String assignedTopic) {
-        this.assignedTopic = assignedTopic;
-    }
-
-    public boolean isActive() {
-        return this.teamUUID != null;
+        this.userUUID = userUUID;
     }
 
     public void update(Map<String, String> newData, ObjectMapper objectMapper) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
@@ -137,19 +137,6 @@ public class StageWithCaseData extends BaseStage {
         this.deadlineWarning = deadlineWarning;
     }
 
-    public void setTransitionNote(UUID transitionNoteUUID) {
-        this.transitionNoteUUID = transitionNoteUUID;
-    }
-
-    public void setTeam(UUID teamUUID) {
-        this.teamUUID = teamUUID;
-        this.userUUID = null;
-    }
-
-    public void setUser(UUID userUUID) {
-        this.userUUID = userUUID;
-    }
-
     public void setAssignedTopic(String assignedTopic) {
         this.assignedTopic = assignedTopic;
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -494,13 +494,13 @@ public class StageServiceTest {
     @Test
     public void shouldUpdateStageTransitionNote() {
 
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Stage stage = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
 
-        when(stageRepository.findActiveByCaseUuidStageUUID(caseUUID, stageUUID)).thenReturn(stage);
+        when(stageRepository.findActiveBasicStageByCaseUuidStageUUID(caseUUID, stageUUID)).thenReturn(stage);
 
         stageService.updateStageCurrentTransitionNote(caseUUID, stageUUID, transitionNoteUUID);
 
-        verify(stageRepository).findActiveByCaseUuidStageUUID(caseUUID, stageUUID);
+        verify(stageRepository).findActiveBasicStageByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
 
         checkNoMoreInteraction();
@@ -510,13 +510,13 @@ public class StageServiceTest {
     @Test
     public void shouldUpdateStageTransitionNoteNull() {
 
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Stage stage = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
 
-        when(stageRepository.findActiveByCaseUuidStageUUID(caseUUID, stageUUID)).thenReturn(stage);
+        when(stageRepository.findActiveBasicStageByCaseUuidStageUUID(caseUUID, stageUUID)).thenReturn(stage);
 
         stageService.updateStageCurrentTransitionNote(caseUUID, stageUUID, null);
 
-        verify(stageRepository).findActiveByCaseUuidStageUUID(caseUUID, stageUUID);
+        verify(stageRepository).findActiveBasicStageByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
 
         checkNoMoreInteraction();

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseDataTest.java
@@ -144,7 +144,7 @@ public class StageWithCaseDataTest {
         assertThat(stage.getCaseDataType()).isEqualTo(null);
         assertThat(stage.getData()).isEqualTo(null);
 
-        stage.setUser(newuserUUID);
+        stage.setUserUUID(newuserUUID);
 
         assertThat(stage.getUuid()).isOfAnyClassIn(UUID.randomUUID().getClass());
         assertThat(stage.getCreated()).isOfAnyClassIn(LocalDateTime.now().getClass());
@@ -184,7 +184,7 @@ public class StageWithCaseDataTest {
         assertThat(stage.getCaseDataType()).isEqualTo(null);
         assertThat(stage.getData()).isEqualTo(null);
 
-        stage.setUser(null);
+        stage.setUserUUID(null);
 
         assertThat(stage.getUuid()).isOfAnyClassIn(UUID.randomUUID().getClass());
         assertThat(stage.getCreated()).isOfAnyClassIn(LocalDateTime.now().getClass());


### PR DESCRIPTION
This commit gets 'updateStageCurrentTransitionNote' to use the simpler (quicker) repository method without the topics/correspondents/case data, and moves some methods that can go on the base object 'baseStage' from the stage subtypes to enable this.