### PR TITLE
Hocs-4235 -'recreateStage' is using a slow query

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -174,7 +174,7 @@ public class StageService {
     }
 
     public void recreateStage(UUID caseUUID, UUID stageUUID, String stageType) {
-        StageWithCaseData stage = stageRepository.findByCaseUuidStageUUID(caseUUID, stageUUID);
+        Stage stage = getBasicStage(caseUUID, stageUUID);
         auditClient.recreateStage(stage);
         updateCurrentStageForCase(caseUUID, stageUUID, stageType);
         log.debug("Recreated Stage {} for Case: {}, event: {}", stageUUID, caseUUID, value(EVENT, STAGE_RECREATED));

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -295,13 +295,13 @@ public class StageServiceTest {
 
     @Test
     public void shouldRecreateStage() {
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Stage stage = new Stage(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
 
-        when(stageRepository.findByCaseUuidStageUUID(caseUUID, stageUUID)).thenReturn(stage);
+        when(stageRepository.findBasicStageByCaseUuidAndStageUuid(caseUUID, stageUUID)).thenReturn(stage);
 
         stageService.recreateStage(caseUUID, stageUUID, stageType);
 
-        verify(stageRepository).findByCaseUuidStageUUID(caseUUID, stageUUID);
+        verify(stageRepository).findBasicStageByCaseUuidAndStageUuid(caseUUID, stageUUID);
         verify(auditClient).recreateStage(stage);
 
         verifyNoMoreInteractions(auditClient, stageRepository, notifyClient);


### PR DESCRIPTION
This commit gets 'recreateStage' to use the simpler (quicker) repository method without the topics/correspondents/case data.