### PR TITLE
Hocs-4235 -'createStage' is using a slow query

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -159,7 +159,7 @@ public class CaseDataService {
     private CaseData getAnyCaseData(UUID caseUUID) {
         log.debug("Getting any Case: {}", caseUUID);
         CaseData caseData = caseDataRepository.findAnyByUuid(caseUUID);
-        if (caseData != null) {
+        if (caseData == null) {
             log.error("Any Case: {}, not found!", caseUUID, value(EVENT, CASE_NOT_FOUND));
             throw new ApplicationExceptions.EntityNotFoundException(String.format("Any Case: %s, not found!", caseUUID), CASE_NOT_FOUND);
         }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -301,23 +301,23 @@ public class CaseDataService {
     }
 
     public void updateCaseData(UUID caseUUID, UUID stageUUID, Map<String, String> data) {
-        if (data != null) {
-            updateCaseData(getCaseData(caseUUID), stageUUID, data);
-        } else {
+        if (data == null) {
             log.warn("Data was null for Case: {} Stage: {}", caseUUID, stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
+        } else {
+            updateCaseData(getCaseData(caseUUID), stageUUID, data);
         }
     }
 
     public void updateCaseData(CaseData caseData, UUID stageUUID, Map<String, String> data) {
         log.debug("Updating data for Case: {}", caseData.getUuid());
-        if (data != null) {
+        if (data == null) {
+            log.warn("Data was null for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
+        } else {
             log.debug("Data size {}", data.size());
             caseData.update(data, objectMapper);
             caseDataRepository.save(caseData);
             auditClient.updateCaseAudit(caseData, stageUUID);
             log.info("Updated Case Data for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_UPDATED));
-        } else {
-            log.warn("Data was null for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
         }
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -189,10 +189,14 @@ public class CaseDataService {
     }
 
     public String getCaseDataField(UUID caseUUID, String key) {
-        log.debug("Looking up key {} for Case: {}", key, caseUUID);
-        Map<String, String> dataMap = getCaseData(caseUUID).getDataMap(objectMapper);
+        return getCaseDataField(getCaseData(caseUUID), key);
+    }
+
+    public String getCaseDataField(CaseData caseData, String key) {
+        log.debug("Looking up key {} for Case: {}", key, caseData.getUuid());
+        Map<String, String> dataMap = caseData.getDataMap(objectMapper);
         String value = dataMap.getOrDefault(key, null);
-        log.debug("returning {} found value for Case: {}", value, caseUUID);
+        log.debug("returning {} found value for Case: {}", value, caseData.getUuid());
         return value;
     }
 
@@ -302,16 +306,21 @@ public class CaseDataService {
     }
 
     public void updateCaseData(UUID caseUUID, UUID stageUUID, Map<String, String> data) {
-        log.debug("Updating data for Case: {}", caseUUID);
+        if (data != null) {
+            updateCaseData(getCaseData(caseUUID), stageUUID, data);
+        }
+    }
+
+    public void updateCaseData(CaseData caseData, UUID stageUUID, Map<String, String> data) {
+        log.debug("Updating data for Case: {}", caseData.getUuid());
         if (data != null) {
             log.debug("Data size {}", data.size());
-            CaseData caseData = getCaseData(caseUUID);
             caseData.update(data, objectMapper);
             caseDataRepository.save(caseData);
             auditClient.updateCaseAudit(caseData, stageUUID);
-            log.info("Updated Case Data for Case: {} Stage: {}", caseUUID, stageUUID, value(EVENT, CASE_UPDATED));
+            log.info("Updated Case Data for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_UPDATED));
         } else {
-            log.warn("Data was null for Case: {} Stage: {}", caseUUID, stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
+            log.warn("Data was null for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
         }
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -303,6 +303,8 @@ public class CaseDataService {
     public void updateCaseData(UUID caseUUID, UUID stageUUID, Map<String, String> data) {
         if (data != null) {
             updateCaseData(getCaseData(caseUUID), stageUUID, data);
+        } else {
+            log.warn("Data was null for Case: {} Stage: {}", caseUUID, stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
         }
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -303,22 +303,24 @@ public class CaseDataService {
     public void updateCaseData(UUID caseUUID, UUID stageUUID, Map<String, String> data) {
         if (data == null) {
             log.warn("Data was null for Case: {} Stage: {}", caseUUID, stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
-        } else {
-            updateCaseData(getCaseData(caseUUID), stageUUID, data);
+            return;
         }
+
+        updateCaseData(getCaseData(caseUUID), stageUUID, data);
     }
 
     public void updateCaseData(CaseData caseData, UUID stageUUID, Map<String, String> data) {
         log.debug("Updating data for Case: {}", caseData.getUuid());
         if (data == null) {
             log.warn("Data was null for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_NOT_UPDATED_NULL_DATA));
-        } else {
-            log.debug("Data size {}", data.size());
-            caseData.update(data, objectMapper);
-            caseDataRepository.save(caseData);
-            auditClient.updateCaseAudit(caseData, stageUUID);
-            log.info("Updated Case Data for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_UPDATED));
+            return;
         }
+
+        log.debug("Data size {}", data.size());
+        caseData.update(data, objectMapper);
+        caseDataRepository.save(caseData);
+        auditClient.updateCaseAudit(caseData, stageUUID);
+        log.info("Updated Case Data for Case: {} Stage: {}", caseData.getUuid(), stageUUID, value(EVENT, CASE_UPDATED));
     }
 
     void updateDateReceived(UUID caseUUID, UUID stageUUID, LocalDate dateReceived, int days) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -126,50 +126,45 @@ public class CaseDataService {
     private CaseData getCaseData(UUID caseUUID) {
         log.debug("Getting Case: {}", caseUUID);
         CaseData caseData = caseDataRepository.findActiveByUuid(caseUUID);
-        if (caseData != null) {
-            log.info("Got Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
-            return caseData;
-        } else {
+        if (caseData == null) {
             log.error("Case: {}, not found!", caseUUID, value(EVENT, CASE_NOT_FOUND));
             throw new ApplicationExceptions.EntityNotFoundException(String.format("Case: %s, not found!", caseUUID), CASE_NOT_FOUND);
         }
+        log.info("Got Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
+        return caseData;
     }
 
     private ActiveCaseViewData getActiveCaseData(UUID caseUUID) {
         log.debug("Getting Case: {}", caseUUID);
         ActiveCaseViewData caseData = activeCaseViewDataRepository.findByUuid(caseUUID);
-        if (caseData != null) {
-            log.info("Got Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
-            return caseData;
-        } else {
+        if (caseData == null) {
             log.error("Case: {}, not found!", caseUUID, value(EVENT, CASE_NOT_FOUND));
             throw new ApplicationExceptions.EntityNotFoundException(String.format("Case: %s, not found!", caseUUID), CASE_NOT_FOUND);
         }
+        log.info("Got Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
+        return caseData;
     }
-
 
     public CaseData getCaseDataByReference(String reference) {
         log.debug("Getting Case by reference: {}", reference);
         CaseData caseData = caseDataRepository.findByReference(reference);
-        if (caseData != null) {
-            log.info("Got Case by reference: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
-            return caseData;
-        } else {
+        if (caseData == null) {
             log.error("Case: {}, not found!", reference, value(EVENT, CASE_NOT_FOUND));
             throw new ApplicationExceptions.EntityNotFoundException(String.format("Case: %s, not found!", reference), CASE_NOT_FOUND);
         }
+        log.info("Got Case by reference: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
+        return caseData;
     }
 
     private CaseData getAnyCaseData(UUID caseUUID) {
         log.debug("Getting any Case: {}", caseUUID);
         CaseData caseData = caseDataRepository.findAnyByUuid(caseUUID);
         if (caseData != null) {
-            log.info("Got any Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
-            return caseData;
-        } else {
             log.error("Any Case: {}, not found!", caseUUID, value(EVENT, CASE_NOT_FOUND));
             throw new ApplicationExceptions.EntityNotFoundException(String.format("Any Case: %s, not found!", caseUUID), CASE_NOT_FOUND);
         }
+        log.info("Got any Case: {}", caseData.getUuid(), value(EVENT, CASE_RETRIEVED));
+        return caseData;
     }
 
     public String getCaseRef(UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -23,6 +23,7 @@ import uk.gov.digital.ho.hocs.casework.api.dto.WithdrawCaseRequest;
 import uk.gov.digital.ho.hocs.casework.application.RequestData;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.UserDto;
+import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
 import uk.gov.digital.ho.hocs.casework.security.AccessLevel;
 import uk.gov.digital.ho.hocs.casework.security.Allocated;
@@ -53,7 +54,7 @@ class StageResource {
     @Authorised(accessLevel = AccessLevel.WRITE)
     @PostMapping(value = "/case/{caseUUID}/stage")
     ResponseEntity<CreateStageResponse> createStage(@PathVariable UUID caseUUID, @RequestBody CreateStageRequest request) {
-        StageWithCaseData stage = stageService.createStage(caseUUID, request.getType(), request.getTeamUUID(), request.getUserUUID(), request.getAllocationType(), request.getTransitionNoteUUID());
+        Stage stage = stageService.createStage(caseUUID, request.getType(), request.getTeamUUID(), request.getUserUUID(), request.getAllocationType(), request.getTransitionNoteUUID());
         return ResponseEntity.ok(CreateStageResponse.from(stage));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateStageResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/CreateStageResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.BaseStage;
 
 import java.util.UUID;
 
@@ -15,7 +15,7 @@ public class CreateStageResponse {
     @JsonProperty("uuid")
     private final UUID uuid;
 
-    public static CreateStageResponse from(StageWithCaseData stage) {
+    public static CreateStageResponse from(BaseStage stage) {
         return new CreateStageResponse(stage.getUuid());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/BaseStage.java
@@ -72,6 +72,10 @@ public abstract class BaseStage implements Serializable {
         this.userUUID = null;
     }
 
+    public void setUser(UUID userUUID) {
+        this.userUUID = userUUID;
+    }
+
     public boolean isActive() {
         return this.teamUUID != null;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
@@ -146,10 +146,6 @@ public class StageWithCaseData extends BaseStage {
         this.userUUID = null;
     }
 
-    public void setUser(UUID userUUID) {
-        this.userUUID = userUUID;
-    }
-
     public void setAssignedTopic(String assignedTopic) {
         this.assignedTopic = assignedTopic;
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -732,14 +732,14 @@ public class CaseDataServiceTest {
     @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
     public void shouldNotUpdateCaseMissingCaseUUIDException() throws ApplicationExceptions.EntityCreationException {
 
-        caseDataService.updateCaseData(null, stageUUID, new HashMap<>());
+        caseDataService.updateCaseData((UUID)null, stageUUID, new HashMap<>());
     }
 
     @Test()
     public void shouldNotUpdateCaseMissingCaseUUID() throws JsonProcessingException {
 
         try {
-            caseDataService.updateCaseData(null, stageUUID, new HashMap<>());
+            caseDataService.updateCaseData((UUID)null, stageUUID, new HashMap<>());
         } catch (ApplicationExceptions.EntityNotFoundException e) {
             // Do nothing.
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -21,6 +21,7 @@ import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageUserRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.WithdrawCaseRequest;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.UserDto;
+import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
 
 import java.io.UnsupportedEncodingException;
@@ -69,7 +70,7 @@ public class StageResourceTest {
     @Test
     public void shouldCreateStage() {
 
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID);
+        Stage stage = new Stage(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID);
         CreateStageRequest request = new CreateStageRequest(stageType, teamUUID, allocationType, transitionNoteUUID, userUUID);
 
         when(stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID)).thenReturn(stage);
@@ -87,7 +88,7 @@ public class StageResourceTest {
     @Test
     public void shouldCreateStageNoTransitionNote() {
 
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, stageType, teamUUID, userUUID, null);
+        Stage stage = new Stage(caseUUID, stageType, teamUUID, userUUID, null);
         CreateStageRequest request = new CreateStageRequest(stageType, teamUUID, allocationType, null, userUUID);
 
         when(stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, null)).thenReturn(stage);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.digital.ho.hocs.casework.client.searchclient.SearchClient;
 import uk.gov.digital.ho.hocs.casework.contributions.ContributionsProcessor;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.BaseStage;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
@@ -113,16 +114,16 @@ public class StageServiceTest {
 
         CaseData caseData = new CaseData(caseDataType, 12344567L, LocalDate.now());
         caseData.setCaseDeadlineWarning(LocalDate.now());
-        when(caseDataService.getCase(caseUUID)).thenReturn(caseData);
-        when(extensionService.hasExtensions(caseUUID)).thenReturn(false);
+        when(caseDataService.getCase(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(false);
 
-        stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
+        stageService.createStage(caseData.getUuid(), stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
-        verify(caseDataService).getCase(caseUUID);
+        verify(caseDataService).getCase(caseData.getUuid());
         verify(infoClient).getStageDeadline(stageType, caseData.getDateReceived(), caseData.getCaseDeadline());
         verify(infoClient).getStageDeadlineWarning(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning());
-        verify(stageRepository).save(any(StageWithCaseData.class));
-        verify(notifyClient).sendTeamEmail(eq(caseUUID), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
+        verify(stageRepository).save(any(Stage.class));
+        verify(notifyClient).sendTeamEmail(eq(caseData.getUuid()), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
 
         verifyNoMoreInteractions(stageRepository);
         verifyNoMoreInteractions(notifyClient);
@@ -142,13 +143,13 @@ public class StageServiceTest {
         caseData.setCaseDeadline(caseDeadline);
         caseData.setCaseDeadlineWarning(caseDeadlineWarning);
 
-        when(caseDataService.getCase(caseUUID)).thenReturn(caseData);
-        when(extensionService.hasExtensions(caseUUID)).thenReturn(true);
+        when(caseDataService.getCase(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(true);
         when(infoClient.getStageDeadlineOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadline())).thenReturn(caseData.getCaseDeadline());
         when(infoClient.getStageDeadlineWarningOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning())).thenReturn(caseData.getCaseDeadlineWarning());
 
         // WHEN
-        StageWithCaseData stage = stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
+        Stage stage = stageService.createStage(caseData.getUuid(), stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
         // THEN
         assertThat(stage.getDeadline()).isEqualTo(caseDeadline);
@@ -171,11 +172,12 @@ public class StageServiceTest {
         caseData.setCaseDeadline(caseDeadline);
         caseData.setCaseDeadlineWarning(caseDeadlineWarning);
 
-        when(caseDataService.getCaseDataField(caseUUID,overrideKey)).thenReturn(overrideDeadline.toString());
-        when(extensionService.hasExtensions(caseUUID)).thenReturn(false);
+        when(caseDataService.getCase(caseData.getUuid())).thenReturn(caseData);
+        when(caseDataService.getCaseDataField(caseData,overrideKey)).thenReturn(overrideDeadline.toString());
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(false);
 
         // WHEN
-        StageWithCaseData stage = stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
+        Stage stage = stageService.createStage(caseData.getUuid(), stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
         // THEN
         assertThat(stage.getDeadline()).isEqualTo(overrideDeadline);
@@ -197,14 +199,15 @@ public class StageServiceTest {
         caseData.setCaseDeadline(caseDeadline);
         caseData.setCaseDeadlineWarning(caseDeadlineWarning);
 
-        when(caseDataService.getCaseDataField(caseUUID,overrideKey)).thenReturn(overrideDeadline.toString());
-        when(caseDataService.getCase(caseUUID)).thenReturn(caseData);
-        when(extensionService.hasExtensions(caseUUID)).thenReturn(true);
+
+        when(caseDataService.getCaseDataField(caseData,overrideKey)).thenReturn(overrideDeadline.toString());
+        when(caseDataService.getCase(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(true);
         when(infoClient.getStageDeadlineOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadline())).thenReturn(caseData.getCaseDeadline());
         when(infoClient.getStageDeadlineWarningOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning())).thenReturn(caseData.getCaseDeadlineWarning());
 
         // WHEN
-        StageWithCaseData stage = stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
+        Stage stage = stageService.createStage(caseData.getUuid(), stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
         // THEN
         assertThat(stage.getDeadline()).isEqualTo(caseDeadline);
@@ -226,14 +229,14 @@ public class StageServiceTest {
         caseData.setCaseDeadline(caseDeadline);
         caseData.setCaseDeadlineWarning(caseDeadlineWarning);
 
-        when(caseDataService.getCaseDataField(caseUUID,overrideKey)).thenReturn(overrideDeadline.toString());
-        when(caseDataService.getCase(caseUUID)).thenReturn(caseData);
-        when(extensionService.hasExtensions(caseUUID)).thenReturn(true);
+        when(caseDataService.getCaseDataField(caseData,overrideKey)).thenReturn(overrideDeadline.toString());
+        when(caseDataService.getCase(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(true);
         when(infoClient.getStageDeadlineOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadline())).thenReturn(caseData.getCaseDeadline());
         when(infoClient.getStageDeadlineWarningOverridingSLA(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning())).thenReturn(caseData.getCaseDeadlineWarning());
 
         // WHEN
-        StageWithCaseData stage = stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
+        Stage stage = stageService.createStage(caseData.getUuid(), stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
         // THEN
         assertThat(stage.getDeadline()).isEqualTo(overrideDeadline);
@@ -248,7 +251,7 @@ public class StageServiceTest {
 
         stageService.createStage(caseUUID, stageType, teamUUID, userUUID, allocationType, transitionNoteUUID);
 
-        verify(auditClient).createStage(any(StageWithCaseData.class));
+        verify(auditClient).createStage(any(BaseStage.class));
         verifyNoMoreInteractions(auditClient);
 
     }


### PR DESCRIPTION
This commit
1) Gets 'createStage' to use the simpler (quicker) repository method without the topics/correspondents/case data.
2) Puts the database code in a transaction as we're modifying two tables
3) Removes multiple calls to getCaseData when one will do.