### PR TITLE
Hocs-4235 -'getTeams' should use the existing getBasicStage method

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -92,6 +92,7 @@ public class StageService {
     }
 
     public UUID getStageUser(UUID caseUUID, UUID stageUUID) {
+        // Should call Active stage because to have a user assigned there should also be a team assigned.
         log.debug("Getting User for Stage: {}", stageUUID);
         Stage stage = getActiveBasicStage(caseUUID, stageUUID);
         log.debug("Got User: {} for Stage: {}", stage.getUserUUID(), stageUUID);
@@ -100,13 +101,7 @@ public class StageService {
 
     public UUID getStageTeam(UUID caseUUID, UUID stageUUID) {
         log.debug("Getting Team for Stage: {}", stageUUID);
-        Stage stage = stageRepository.findBasicStageByCaseUuidAndStageUuid(caseUUID, stageUUID);
-
-        if (stage == null) {
-            log.warn("No team exists is linked to stage: {} and case: {}", stageUUID, caseUUID);
-            return null;
-        }
-
+        Stage stage = getBasicStage(caseUUID, stageUUID);
         log.info("Team: {} exists is linked to stage: {} and case: {}", stage.getTeamUUID(), stageUUID, caseUUID, stageUUID);
         return stage.getTeamUUID();
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -91,8 +91,10 @@ public class StageService {
         this.extensionService = extensionService;
     }
 
+    /**
+     * This method should call Active basic stage because to have a user assigned there should also be a team assigned.
+     */
     public UUID getStageUser(UUID caseUUID, UUID stageUUID) {
-        // Should call Active stage because to have a user assigned there should also be a team assigned.
         log.debug("Getting User for Stage: {}", stageUUID);
         Stage stage = getActiveBasicStage(caseUUID, stageUUID);
         log.debug("Got User: {} for Stage: {}", stage.getUserUUID(), stageUUID);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -996,19 +996,14 @@ public class StageServiceTest {
         verifyNoMoreInteractions(stageRepository);
     }
 
-    @Test
+    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
     public void getStageTeam_nullResult() {
         var caseUuid = UUID.randomUUID();
         var stageUuid = UUID.randomUUID();
 
         when(stageRepository.findBasicStageByCaseUuidAndStageUuid(any(), any())).thenReturn(null);
 
-        var result = stageService.getStageTeam(caseUuid, stageUuid);
-        assertThat(result).isNull();
-
-        verify(stageRepository).findBasicStageByCaseUuidAndStageUuid(caseUuid, stageUuid);
-
-        verifyNoMoreInteractions(stageRepository);
+        stageService.getStageTeam(caseUuid, stageUuid);
     }
 
     /**


### PR DESCRIPTION
This commit moves 'getTeams' to use the existing getBasicStage method, this isn't an important change on its own but it is the first part of being able to return a 'Stage' object in callers to the Casework service instead of calling it n times in one method for specific fields as we do now.

It also puts back an exception where there stageUUID is not found in the database - this is different to 'inactive' stages which don't have teams assigned to them