### PR TITLE
Hocs-4235 -'getRef' is always called when we have access to the ref already

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
@@ -1,11 +1,5 @@
 package uk.gov.digital.ho.hocs.casework.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -14,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.digital.ho.hocs.casework.api.dto.ActionDataAppealDto;
 import uk.gov.digital.ho.hocs.casework.api.dto.ActionDataDto;
-import uk.gov.digital.ho.hocs.casework.api.dto.AppealOfficerDto;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.CaseTypeActionDto;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
@@ -25,7 +18,6 @@ import uk.gov.digital.ho.hocs.casework.domain.repository.ActionDataAppealsReposi
 import uk.gov.digital.ho.hocs.casework.domain.repository.CaseDataRepository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -59,7 +51,7 @@ public class ActionDataAppealsService implements ActionService {
         return "appeals";
     }
 
-    public UUID createAppeal(UUID caseUuid, UUID stageUuid, ActionDataAppealDto appealDto) {
+    public ActionDataAppeal createAppeal(UUID caseUuid, UUID stageUuid, ActionDataAppealDto appealDto) {
 
         log.debug("Received request to create Appeal: {} for case: {}, stage: {}", appealDto, caseUuid, stageUuid);
         UUID appealUuid = appealDto.getCaseTypeActionUuid();
@@ -101,10 +93,10 @@ public class ActionDataAppealsService implements ActionService {
         auditClient.createAppealAudit(createdAppealEntity, caseTypeActionDto);
         log.info("Created Action: {}  for Case: {}", createdAppealEntity, caseData.getUuid(), value(EVENT, ACTION_DATA_CREATE_SUCCESS) );
 
-        return createdAppealEntity.getUuid();
+        return createdAppealEntity;
     }
 
-    public void updateAppeal(UUID caseUuid, UUID actionEntityId, ActionDataAppealDto appealDto) {
+    public String updateAppeal(UUID caseUuid, UUID actionEntityId, ActionDataAppealDto appealDto) {
 
         log.debug("Received request to update Appeal: {} for case: {}", appealDto, caseUuid);
 
@@ -138,6 +130,7 @@ public class ActionDataAppealsService implements ActionService {
         auditClient.updateAppealAudit(updatedAppealEntity, caseTypeActionDto);
         log.info("Updated Action: {}  for Case: {}", appealDto, caseData.getUuid(), value(EVENT, ACTION_DATA_UPDATE_SUCCESS) );
 
+        return caseData.getReference();
     }
 
     /**

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataDeadlineExtensionService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataDeadlineExtensionService.java
@@ -61,7 +61,7 @@ public class ActionDataDeadlineExtensionService implements ActionService {
         return extensionRepository.existsDistinctByCaseDataUuid(caseUUID);
     }
 
-    public void createExtension(UUID caseUuid, UUID stageUuid, ActionDataDeadlineExtensionInboundDto extensionDto) {
+    public String createExtension(UUID caseUuid, UUID stageUuid, ActionDataDeadlineExtensionInboundDto extensionDto) {
 
         log.debug("Received request to create extension: {} for case: {}, stage: {}", extensionDto, caseUuid, stageUuid);
 
@@ -128,6 +128,8 @@ public class ActionDataDeadlineExtensionService implements ActionService {
         auditClient.createExtensionAudit(createdExtension);
 
         log.info("Created action:  {} for case: {}", createdExtension, caseUuid);
+
+        return caseData.getReference();
     }
 
     private boolean hasMaxRequests(CaseTypeActionDto caseTypeActionDto, UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestService.java
@@ -53,7 +53,7 @@ public class ActionDataExternalInterestService implements ActionService {
         return "recordInterest";
     }
 
-    public void createExternalInterest(UUID caseUuid, UUID stageUuid, ActionDataExternalInterestInboundDto interestDto) {
+    public String createExternalInterest(UUID caseUuid, UUID stageUuid, ActionDataExternalInterestInboundDto interestDto) {
 
         log.debug("Received request to create external " +
                 "interest: {} for case: {}, stage: {}", interestDto, caseUuid, stageUuid);
@@ -93,9 +93,11 @@ public class ActionDataExternalInterestService implements ActionService {
         auditClient.createExternalInterestAudit(actionDataExternalInterest);
 
         log.info("Created action:  {} for case: {}", interestDto, caseUuid);
+
+        return caseData.getReference();
     }
 
-    public void updateExternalInterest(UUID caseUuid, UUID actionEntityId, ActionDataExternalInterestInboundDto updateExternalInterestDto) {
+    public String updateExternalInterest(UUID caseUuid, UUID actionEntityId, ActionDataExternalInterestInboundDto updateExternalInterestDto) {
         log.debug("Received request to update external interest: {} for case: {}", updateExternalInterestDto, caseUuid);
 
         CaseData caseData = caseDataRepository.findActiveByUuid(caseUuid);
@@ -129,6 +131,8 @@ public class ActionDataExternalInterestService implements ActionService {
         actionDataExternalInterestRepository.save(existingExternalInterestData);
 
         auditClient.updateExternalInterestAudit(existingExternalInterestData);
+
+        return caseData.getReference();
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseActionsResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseActionsResource.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.hocs.casework.api.dto.*;
+import uk.gov.digital.ho.hocs.casework.domain.model.ActionDataAppeal;
 
 import java.util.UUID;
 
@@ -19,17 +20,14 @@ public class CaseActionsResource {
     private final ActionDataDeadlineExtensionService extensionService;
     private final ActionDataAppealsService appealsService;
     private final ActionDataExternalInterestService externalInterestService;
-    private final CaseDataService caseDataService;
 
     @Autowired
     public CaseActionsResource(CaseActionService caseActionService, ActionDataDeadlineExtensionService extensionService,
-                               ActionDataAppealsService appealsService, ActionDataExternalInterestService externalInterestService,
-                               CaseDataService caseDataService) {
+                               ActionDataAppealsService appealsService, ActionDataExternalInterestService externalInterestService) {
         this.caseActionService = caseActionService;
         this.extensionService = extensionService;
         this.appealsService = appealsService;
         this.externalInterestService = externalInterestService;
-        this.caseDataService = caseDataService;
     }
 
     @GetMapping(path = "/case/{caseId}/actions")
@@ -44,8 +42,8 @@ public class CaseActionsResource {
                                                                     @PathVariable UUID stageUUID,
                                                                     @RequestBody ActionDataDeadlineExtensionInboundDto extensionData) {
 
-        extensionService.createExtension(caseUUID, stageUUID, extensionData);
-        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseDataService.getCaseRef(caseUUID)));
+        String caseRef = extensionService.createExtension(caseUUID, stageUUID, extensionData);
+        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
 
     // ---- Case Appeals ----
@@ -54,8 +52,8 @@ public class CaseActionsResource {
                                                                  @PathVariable UUID stageUUID,
                                                                  @RequestBody ActionDataAppealDto appealData) {
 
-        final UUID actionUUID = appealsService.createAppeal(caseUUID, stageUUID, appealData);
-        return ResponseEntity.ok(new CreateActionDataResponse(actionUUID, caseUUID, caseDataService.getCaseRef(caseUUID)));
+        ActionDataAppeal appeal = appealsService.createAppeal(caseUUID, stageUUID, appealData);
+        return ResponseEntity.ok(new CreateActionDataResponse(appeal.getUuid(), caseUUID, appeal.getCaseReference()));
     }
 
     @PutMapping(path = "/case/{caseUUID}/stage/{stageUUID}/actions/appeal/{appealUUID}")
@@ -64,8 +62,8 @@ public class CaseActionsResource {
                                                                  @PathVariable UUID appealUUID,
                                                                  @RequestBody ActionDataAppealDto extensionData) {
 
-        appealsService.updateAppeal(caseUUID, appealUUID, extensionData);
-        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseDataService.getCaseRef(caseUUID)));
+        String caseRef = appealsService.updateAppeal(caseUUID, appealUUID, extensionData);
+        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
 
     // ---- Register External Interest ----
@@ -74,8 +72,8 @@ public class CaseActionsResource {
                                                                            @PathVariable UUID stageUUID,
                                                                            @RequestBody ActionDataExternalInterestInboundDto interestData) {
 
-        externalInterestService.createExternalInterest(caseUUID, stageUUID, interestData);
-        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseDataService.getCaseRef(caseUUID)));
+        String caseRef = externalInterestService.createExternalInterest(caseUUID, stageUUID, interestData);
+        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
 
     @PutMapping(path = "/case/{caseUUID}/stage/{stageUUID}/actions/interest/{interestUUID}")
@@ -84,7 +82,7 @@ public class CaseActionsResource {
                                                                     @PathVariable UUID interestUUID,
                                                                     @RequestBody ActionDataExternalInterestInboundDto extensionData) {
 
-        externalInterestService.updateExternalInterest(caseUUID, interestUUID, extensionData);
-        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseDataService.getCaseRef(caseUUID)));
+        String caseRef = externalInterestService.updateExternalInterest(caseUUID, interestUUID, extensionData);
+        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -198,10 +198,9 @@ class CaseDataResource {
         return ResponseEntity.ok(GetCaseResponse.from(caseData, true));
     }
 
-    @Cacheable (value = "UUIDToCaseReference")
     @GetMapping(value = "/case/reference/{caseUUID}")
     public ResponseEntity<GetCaseReferenceResponse> getCaseReference(@PathVariable UUID caseUUID) {
-        final String caseRef = caseDataService.getCaseDataCaseRef(caseUUID);
-        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
+        CaseData caseData = caseDataService.getCase(caseUUID);
+        return ResponseEntity.ok(GetCaseReferenceResponse.from(caseData.getUuid(), caseData.getReference()));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -172,22 +172,6 @@ public class CaseDataService {
         }
     }
 
-    public String getCaseRef(UUID caseUUID) {
-        log.debug("Looking up CaseRef for Case: {}", caseUUID);
-        String caseRef = caseDataRepository.getCaseRef(caseUUID);
-        log.debug("CaseRef {} found for Case: {}", caseRef, caseUUID);
-
-        return caseRef;
-    }
-
-    public String getCaseDataCaseRef(UUID caseUUID) {
-        log.debug("Looking up CaseRef on all cases for Case: {}", caseUUID);
-        String caseRef = caseDataRepository.getCaseDataCaseRef(caseUUID);
-        log.debug("CaseRef {} found for Case: {}", caseRef, caseUUID);
-
-        return caseRef;
-    }
-
     public String getCaseDataField(UUID caseUUID, String key) {
         log.debug("Looking up key {} for Case: {}", key, caseUUID);
         Map<String, String> dataMap = getCaseData(caseUUID).getDataMap(objectMapper);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/ActionDataAppeal.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/ActionDataAppeal.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -71,6 +72,9 @@ public class ActionDataAppeal implements Serializable {
 
     @Column(name = "document")
     private UUID document;
+
+    @Transient
+    private String caseReference;
 
     public ActionDataAppeal(UUID caseTypeActionUuid,
                             String caseTypeActionLabel,

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataRepository.java
@@ -19,15 +19,9 @@ public interface CaseDataRepository extends CrudRepository<CaseData, Long> {
     @Query(value = "SELECT ac.* FROM case_data ac where ac.reference = ?1", nativeQuery = true)
     CaseData findByReference(String reference);
 
-    @Query(value = "SELECT ac.reference FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
-    String getCaseRef(UUID uuid);
-
     @Query(value = "SELECT ac.type FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
     String getCaseType(UUID uuid);
 
     @Query(value = "SELECT cd.* FROM view_case_data cd WHERE cd.uuid = ?1", nativeQuery = true)
     CaseData findAnyByUuid(UUID uuid);
-
-    @Query(value = "SELECT ac.reference FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
-    String getCaseDataCaseRef(UUID uuid);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsServiceTest.java
@@ -225,13 +225,13 @@ public class ActionDataAppealsServiceTest {
         when(mockAppealRepository.save((any()))).thenReturn(createdActionDataAppeal);
 
         // WHEN
-        final UUID appealUuid = actionDataAppealsService.createAppeal(caseUUID, stageUUID, appealDto);
+        final ActionDataAppeal appeal = actionDataAppealsService.createAppeal(caseUUID, stageUUID, appealDto);
 
         // THEN
         verify(mockAppealRepository, times(1)).save(appealArgumentCaptor.capture());
 
         assertThat(appealArgumentCaptor.getValue().getCaseTypeActionUuid()).isEqualTo(actionTypeUuid);
-        assertThat(appealUuid).isEqualTo(createdActionDataAppeal.getUuid());
+        assertThat(appeal.getUuid()).isEqualTo(createdActionDataAppeal.getUuid());
 
         verify(mockCaseDataRepository, times(1)).findActiveByUuid(caseUUID);
         verify(mockCaseNoteService, times(1)).createCaseNote(eq(caseUUID), eq("APPEAL_CREATED"), anyString());
@@ -459,6 +459,7 @@ public class ActionDataAppealsServiceTest {
                 "{}",
                 LocalDateTime.MIN,
                 LocalDateTime.MIN,
+                null,
                 null
         );
 
@@ -477,6 +478,7 @@ public class ActionDataAppealsServiceTest {
                 updatedDataField,
                 LocalDateTime.MIN,
                 LocalDateTime.MIN,
+                null,
                 null
         );
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
@@ -371,20 +371,4 @@ public class CaseDataResourceTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
-    @Test
-    public void getCaseReferenceValue() {
-        String reference = "CASE/123456/789";
-
-        when(caseDataService.getCaseDataCaseRef(uuid)).thenReturn(reference);
-
-        final ResponseEntity<GetCaseReferenceResponse> caseReferenceResponse = caseDataResource.getCaseReference(uuid);
-
-        assertThat(caseReferenceResponse).isNotNull();
-        assertThat(caseReferenceResponse.getBody()).isNotNull();
-        assertThat(caseReferenceResponse.getBody().getReference()).isEqualTo(reference);
-        verify(caseDataService).getCaseDataCaseRef(uuid);
-        verifyNoMoreInteractions(caseDataService);
-
-    }
 }
-

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -945,19 +945,6 @@ public class CaseDataServiceTest {
     }
 
     @Test
-    public void getCaseRef() {
-
-        when(caseDataRepository.getCaseRef(caseUUID)).thenReturn(caseRef);
-
-        String result = caseDataService.getCaseRef(caseUUID);
-
-        assertThat(result).isEqualTo(caseRef);
-        verify(caseDataRepository).getCaseRef(caseUUID);
-        verifyNoMoreInteractions(infoClient, caseDataRepository, auditClient);
-
-    }
-
-    @Test
     public void updateDeadlineForStages() {
 
         Map<String, Integer> stageTypeAndDaysMap = Map.ofEntries(Map.entry("type1", 5),

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -122,7 +122,7 @@ public class StageServiceTest {
         verify(infoClient).getStageDeadline(stageType, caseData.getDateReceived(), caseData.getCaseDeadline());
         verify(infoClient).getStageDeadlineWarning(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning());
         verify(stageRepository).save(any(StageWithCaseData.class));
-        verify(notifyClient).sendTeamEmail(eq(caseUUID), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
+        verify(notifyClient).sendTeamEmail(eq(caseUUID), any(UUID.class), eq(teamUUID), eq(caseData.getReference()), eq(allocationType));
 
         verifyNoMoreInteractions(stageRepository);
         verifyNoMoreInteractions(notifyClient);
@@ -171,6 +171,7 @@ public class StageServiceTest {
         caseData.setCaseDeadline(caseDeadline);
         caseData.setCaseDeadlineWarning(caseDeadlineWarning);
 
+        when(caseDataService.getCase(caseUUID)).thenReturn(caseData);
         when(caseDataService.getCaseDataField(caseUUID,overrideKey)).thenReturn(overrideDeadline.toString());
         when(extensionService.hasExtensions(caseUUID)).thenReturn(false);
 
@@ -535,7 +536,6 @@ public class StageServiceTest {
         verify(stageRepository).findByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
         verify(auditClient).updateStageTeam(stage);
-        verify(caseDataService).getCaseRef(caseUUID);
         verify(notifyClient).sendTeamEmail(eq(caseUUID), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
 
         checkNoMoreInteraction();
@@ -556,7 +556,6 @@ public class StageServiceTest {
         verify(stageRepository).findByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
         verify(notifyClient).sendTeamEmail(caseUUID, stage.getUuid(), teamUUID, null, null);
-        verify(caseDataService).getCaseRef(caseUUID);
 
         checkNoMoreInteraction();
 
@@ -808,7 +807,6 @@ public class StageServiceTest {
         auditType.add(STAGE_ALLOCATED_TO_USER.name());
         final Set<GetAuditResponse> auditLines = getAuditLines(stage);
         when(auditClient.getAuditLinesForCase(caseUUID, auditType)).thenReturn(auditLines);
-        when(caseDataService.getCaseRef(caseUUID)).thenReturn("MIN/1234567/19");
         stageService.checkSendOfflineQAEmail(stage);
         verify(auditClient).getAuditLinesForCase(caseUUID, auditType);
         verify(notifyClient).sendOfflineQaEmail(stage.getCaseUUID(), stage.getUuid(), UUID.fromString(userID), offlineQaUserUUID, stage.getCaseReference());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
@@ -451,9 +451,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference() {
         Stage stage = createActiveStageWithActiveCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findActiveByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(1, returnedStages.size());
         assertEquals(returnedStages.stream().findFirst().get().getUuid(), stage.getUuid());
@@ -462,9 +462,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference_InactiveStage() {
         Stage stage = createInactiveStageWithActiveCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findActiveByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(1, returnedStages.size());
         assertEquals(returnedStages.stream().findFirst().get().getUuid(), stage.getUuid());
@@ -474,9 +474,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference_DeletedCase() {
         Stage stage = createActiveStageWithDeletedCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findAnyByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(0, returnedStages.size());
     }


### PR DESCRIPTION
This commit removes 'getCaseRef' as every time it is called we already have access to the case reference and we don't need to fetch it again from the case_data table.