### PR TITLE
Hocs-4235 -'getRef' is always called when we have access to the reference already

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -201,7 +201,7 @@ class CaseDataResource {
     @Cacheable (value = "UUIDToCaseReference")
     @GetMapping(value = "/case/reference/{caseUUID}")
     public ResponseEntity<GetCaseReferenceResponse> getCaseReference(@PathVariable UUID caseUUID) {
-        final String caseRef = caseDataService.getCaseDataCaseRef(caseUUID);
+        final String caseRef = caseDataService.getCaseRef(caseUUID);
         return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -169,18 +169,9 @@ public class CaseDataService {
 
     public String getCaseRef(UUID caseUUID) {
         log.debug("Looking up CaseRef for Case: {}", caseUUID);
-        String caseRef = caseDataRepository.getCaseRef(caseUUID);
-        log.debug("CaseRef {} found for Case: {}", caseRef, caseUUID);
-
-        return caseRef;
-    }
-
-    public String getCaseDataCaseRef(UUID caseUUID) {
-        log.debug("Looking up CaseRef on all cases for Case: {}", caseUUID);
-        String caseRef = caseDataRepository.getCaseDataCaseRef(caseUUID);
-        log.debug("CaseRef {} found for Case: {}", caseRef, caseUUID);
-
-        return caseRef;
+        CaseData caseData = caseDataRepository.findActiveByUuid(caseUUID);
+        log.debug("CaseRef {} found for Case: {}", caseData.getReference(), caseUUID);
+        return caseData.getReference();
     }
 
     public String getCaseDataField(UUID caseUUID, String key) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -138,7 +138,7 @@ public class StageService {
         caseDataService.updateCaseData(caseData, stage.getUuid(), Map.of(CaseworkConstants.CURRENT_STAGE, stageType));
         auditClient.createStage(stage);
         log.info("Created Stage: {}, Type: {}, Case: {}, event: {}", stage.getUuid(), stage.getStageType(), stage.getCaseUUID(), value(EVENT, STAGE_CREATED));
-        notifyClient.sendTeamEmail(caseUUID, stage.getUuid(), teamUUID, getCaseRef(caseUUID), emailType);
+        notifyClient.sendTeamEmail(caseUUID, stage.getUuid(), teamUUID, caseData.getReference(), emailType);
         return stage;
     }
 
@@ -200,7 +200,7 @@ public class StageService {
             log.info("Completed Stage ({}) for Case {}", stageUUID, caseUUID, value(EVENT, STAGE_COMPLETED));
         } else {
             log.info("Set Stage Team: {} ({}) for Case {}", stageUUID, newTeamUUID, caseUUID, value(EVENT, STAGE_ASSIGNED_TEAM));
-            notifyClient.sendTeamEmail(caseUUID, stage.getUuid(), newTeamUUID, getCaseRef(caseUUID), emailType);
+            notifyClient.sendTeamEmail(caseUUID, stage.getUuid(), newTeamUUID, stage.getCaseReference(), emailType);
         }
     }
 
@@ -210,7 +210,7 @@ public class StageService {
             final UUID stageUserUUID = getLastCaseUserUUID(stage.getCaseUUID());
             if (offlineQaUser != null && stageUserUUID != null) {
                 UUID offlineQaUserUUID = UUID.fromString(offlineQaUser);
-                notifyClient.sendOfflineQaEmail(stage.getCaseUUID(), stage.getUuid(), stageUserUUID, offlineQaUserUUID, getCaseRef(stage.getCaseUUID()));
+                notifyClient.sendOfflineQaEmail(stage.getCaseUUID(), stage.getUuid(), stageUserUUID, offlineQaUserUUID, stage.getCaseReference());
             }
         }
     }
@@ -252,7 +252,7 @@ public class StageService {
         stageRepository.save(stage);
         auditClient.updateStageUser(stage);
         log.info("Updated User: {} for Stage {}", newUserUUID, stageUUID, value(EVENT, STAGE_ASSIGNED_USER));
-        notifyClient.sendUserEmail(caseUUID, stage.getUuid(), currentUserUUID, newUserUUID, getCaseRef(caseUUID));
+        notifyClient.sendUserEmail(caseUUID, stage.getUuid(), currentUserUUID, newUserUUID, stage.getCaseReference());
     }
 
     Set<StageWithCaseData> getActiveStagesByCaseUUID(UUID caseUUID) {
@@ -463,10 +463,6 @@ public class StageService {
             Optional<StageWithCaseData> maxDatedStage = stageSupplier.get().max(CREATED_COMPARATOR);
             return maxDatedStage.stream();
         }
-    }
-
-    private String getCaseRef(UUID caseUUID) {
-        return caseDataService.getCaseRef(caseUUID);
     }
 
     private void updatePriority(StageWithCaseData stage) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataRepository.java
@@ -19,15 +19,9 @@ public interface CaseDataRepository extends CrudRepository<CaseData, Long> {
     @Query(value = "SELECT ac.* FROM case_data ac where ac.reference = ?1", nativeQuery = true)
     CaseData findByReference(String reference);
 
-    @Query(value = "SELECT ac.reference FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
-    String getCaseRef(UUID uuid);
-
     @Query(value = "SELECT ac.type FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
     String getCaseType(UUID uuid);
 
     @Query(value = "SELECT cd.* FROM view_case_data cd WHERE cd.uuid = ?1", nativeQuery = true)
     CaseData findAnyByUuid(UUID uuid);
-
-    @Query(value = "SELECT ac.reference FROM case_data ac where ac.uuid = ?1", nativeQuery = true)
-    String getCaseDataCaseRef(UUID uuid);
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
@@ -39,7 +39,6 @@ public class CaseDataResourceTest {
     public static final String PREVIOUS_CASE_REFERENCE = "COMP/1234567/21";
     public static final UUID PREVIOUS_CASE_UUID = UUID.randomUUID();
     public static final UUID PREVIOUS_STAGE_UUID = UUID.randomUUID();
-    public static final UUID RANDOM_UUID = UUID.randomUUID();
     public static final UUID FROM_CASE_UUID = UUID.randomUUID();
     private final CaseDataType caseDataType = CaseDataTypeFactory.from("MIN", "a1");
     private final HashMap<String, String> data = new HashMap<>();
@@ -370,21 +369,4 @@ public class CaseDataResourceTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
-
-    @Test
-    public void getCaseReferenceValue() {
-        String reference = "CASE/123456/789";
-
-        when(caseDataService.getCaseDataCaseRef(uuid)).thenReturn(reference);
-
-        final ResponseEntity<GetCaseReferenceResponse> caseReferenceResponse = caseDataResource.getCaseReference(uuid);
-
-        assertThat(caseReferenceResponse).isNotNull();
-        assertThat(caseReferenceResponse.getBody()).isNotNull();
-        assertThat(caseReferenceResponse.getBody().getReference()).isEqualTo(reference);
-        verify(caseDataService).getCaseDataCaseRef(uuid);
-        verifyNoMoreInteractions(caseDataService);
-
-    }
 }
-

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -945,19 +945,6 @@ public class CaseDataServiceTest {
     }
 
     @Test
-    public void getCaseRef() {
-
-        when(caseDataRepository.getCaseRef(caseUUID)).thenReturn(caseRef);
-
-        String result = caseDataService.getCaseRef(caseUUID);
-
-        assertThat(result).isEqualTo(caseRef);
-        verify(caseDataRepository).getCaseRef(caseUUID);
-        verifyNoMoreInteractions(infoClient, caseDataRepository, auditClient);
-
-    }
-
-    @Test
     public void updateDeadlineForStages() {
 
         Map<String, Integer> stageTypeAndDaysMap = Map.ofEntries(Map.entry("type1", 5),

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -809,7 +809,6 @@ public class StageServiceTest {
         auditType.add(STAGE_ALLOCATED_TO_USER.name());
         final Set<GetAuditResponse> auditLines = getAuditLines(stage);
         when(auditClient.getAuditLinesForCase(caseUUID, auditType)).thenReturn(auditLines);
-        when(caseDataService.getCaseRef(caseUUID)).thenReturn("MIN/1234567/19");
         stageService.checkSendOfflineQAEmail(stage);
         verify(auditClient).getAuditLinesForCase(caseUUID, auditType);
         verify(notifyClient).sendOfflineQaEmail(stage.getCaseUUID(), stage.getUuid(), UUID.fromString(userID), offlineQaUserUUID, stage.getCaseReference());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -123,7 +123,7 @@ public class StageServiceTest {
         verify(infoClient).getStageDeadline(stageType, caseData.getDateReceived(), caseData.getCaseDeadline());
         verify(infoClient).getStageDeadlineWarning(stageType, caseData.getDateReceived(), caseData.getCaseDeadlineWarning());
         verify(stageRepository).save(any(Stage.class));
-        verify(notifyClient).sendTeamEmail(eq(caseData.getUuid()), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
+        verify(notifyClient).sendTeamEmail(eq(caseData.getUuid()), any(UUID.class), eq(teamUUID), eq(caseData.getReference()), eq(allocationType));
 
         verifyNoMoreInteractions(stageRepository);
         verifyNoMoreInteractions(notifyClient);
@@ -538,7 +538,6 @@ public class StageServiceTest {
         verify(stageRepository).findByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
         verify(auditClient).updateStageTeam(stage);
-        verify(caseDataService).getCaseRef(caseUUID);
         verify(notifyClient).sendTeamEmail(eq(caseUUID), any(UUID.class), eq(teamUUID), eq(null), eq(allocationType));
 
         checkNoMoreInteraction();
@@ -559,7 +558,6 @@ public class StageServiceTest {
         verify(stageRepository).findByCaseUuidStageUUID(caseUUID, stageUUID);
         verify(stageRepository).save(stage);
         verify(notifyClient).sendTeamEmail(caseUUID, stage.getUuid(), teamUUID, null, null);
-        verify(caseDataService).getCaseRef(caseUUID);
 
         checkNoMoreInteraction();
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepositoryTest.java
@@ -451,9 +451,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference() {
         Stage stage = createActiveStageWithActiveCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findActiveByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(1, returnedStages.size());
         assertEquals(returnedStages.stream().findFirst().get().getUuid(), stage.getUuid());
@@ -462,9 +462,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference_InactiveStage() {
         Stage stage = createInactiveStageWithActiveCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findActiveByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(1, returnedStages.size());
         assertEquals(returnedStages.stream().findFirst().get().getUuid(), stage.getUuid());
@@ -474,9 +474,9 @@ public class StageRepositoryTest {
     @Test
     public void findByCaseReference_DeletedCase() {
         Stage stage = createActiveStageWithDeletedCase();
-        String caseDataRef = caseDataRepository.getCaseRef(stage.getCaseUUID());
+        CaseData caseData = caseDataRepository.findAnyByUuid(stage.getCaseUUID());
 
-        var returnedStages = stageRepository.findByCaseReference(caseDataRef);
+        var returnedStages = stageRepository.findByCaseReference(caseData.getReference());
 
         assertEquals(0, returnedStages.size());
     }


### PR DESCRIPTION
'getRef' is always called when we have access to the reference already

This commit removes 'getCaseRef' as every time it is called we already have access to the case reference and we don't need to fetch it again from the case_data table.