### PR TITLE
HOCS-4198 Extra blank case note when adding/updating appeals and 'System Event' log in timeline when an extension is applied

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
@@ -40,10 +40,6 @@ public class ActionDataAppealsService implements ActionService {
     private final CaseDataRepository caseDataRepository;
     private final InfoClient infoClient;
     private final AuditClient auditClient;
-    private final CaseNoteService caseNoteService;
-
-    private static final String CREATE_CASE_NOTE_KEY = "APPEAL_CREATED";
-    private static final String UPDATE_CASE_NOTE_KEY = "APPEAL_UPDATED";
 
     @Autowired
     public ActionDataAppealsService(ActionDataAppealsRepository appealsRepository, CaseDataRepository caseDataRepository, InfoClient infoClient, AuditClient auditClient, CaseNoteService caseNoteService) {
@@ -51,7 +47,6 @@ public class ActionDataAppealsService implements ActionService {
         this.caseDataRepository = caseDataRepository;
         this.infoClient = infoClient;
         this.auditClient = auditClient;
-        this.caseNoteService = caseNoteService;
     }
 
     @Override
@@ -97,7 +92,6 @@ public class ActionDataAppealsService implements ActionService {
         );
 
         ActionDataAppeal createdAppealEntity = appealsRepository.save(appealEntity);
-        caseNoteService.createCaseNote(caseUuid, CREATE_CASE_NOTE_KEY, appealEntity.getCaseTypeActionLabel());
         auditClient.createAppealAudit(createdAppealEntity, caseTypeActionDto);
         log.info("Created Action: {}  for Case: {}", createdAppealEntity, caseData.getUuid(), value(EVENT, ACTION_DATA_CREATE_SUCCESS) );
 
@@ -134,7 +128,6 @@ public class ActionDataAppealsService implements ActionService {
 
         ActionDataAppeal updatedAppealEntity = appealsRepository.save(existingAppealData);
 
-        caseNoteService.createCaseNote(caseUuid, UPDATE_CASE_NOTE_KEY, updatedAppealEntity.getCaseTypeActionLabel());
         auditClient.updateAppealAudit(updatedAppealEntity, caseTypeActionDto);
         log.info("Updated Action: {}  for Case: {}", appealDto, caseData.getUuid(), value(EVENT, ACTION_DATA_UPDATE_SUCCESS) );
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsService.java
@@ -42,7 +42,10 @@ public class ActionDataAppealsService implements ActionService {
     private final AuditClient auditClient;
 
     @Autowired
-    public ActionDataAppealsService(ActionDataAppealsRepository appealsRepository, CaseDataRepository caseDataRepository, InfoClient infoClient, AuditClient auditClient, CaseNoteService caseNoteService) {
+    public ActionDataAppealsService(ActionDataAppealsRepository appealsRepository,
+                                    CaseDataRepository caseDataRepository,
+                                    InfoClient infoClient,
+                                    AuditClient auditClient) {
         this.appealsRepository = appealsRepository;
         this.caseDataRepository = caseDataRepository;
         this.infoClient = infoClient;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestService.java
@@ -30,22 +30,16 @@ public class ActionDataExternalInterestService implements ActionService {
     private final CaseDataRepository caseDataRepository;
     private final InfoClient infoClient;
     private final AuditClient auditClient;
-    private final CaseNoteService caseNoteService;
-
-    private static final String CREATE_CASE_NOTE_KEY = "RECORD_INTEREST";
-    private static final String UPDATE_CASE_NOTE_KEY = "UPDATE_INTEREST";
 
     @Autowired
     public ActionDataExternalInterestService(ActionDataExternalInterestRepository actionDataExternalInterestRepository,
                                              CaseDataRepository caseDataRepository,
                                              InfoClient infoClient,
-                                             AuditClient auditClient,
-                                             CaseNoteService caseNoteService) {
+                                             AuditClient auditClient) {
         this.actionDataExternalInterestRepository = actionDataExternalInterestRepository;
         this.caseDataRepository = caseDataRepository;
         this.infoClient = infoClient;
         this.auditClient = auditClient;
-        this.caseNoteService = caseNoteService;
     }
 
     @Override
@@ -86,8 +80,6 @@ public class ActionDataExternalInterestService implements ActionService {
         EntityDto<Map<String, String>> partyType = infoClient.getEntityBySimpleName(actionDataExternalInterest.getPartyType());
         String partyTitle = partyType.getData().get("title");
 
-        caseNoteService.createCaseNote(caseUuid, CREATE_CASE_NOTE_KEY,
-                partyTitle + ": " + actionDataExternalInterest.getDetailsOfInterest());
         actionDataExternalInterestRepository.save(actionDataExternalInterest);
 
         auditClient.createExternalInterestAudit(actionDataExternalInterest);
@@ -124,8 +116,6 @@ public class ActionDataExternalInterestService implements ActionService {
         EntityDto<Map<String, String>> partyType = infoClient.getEntityBySimpleName(existingExternalInterestData.getPartyType());
         String partyTitle = partyType.getData().get("title");
 
-        caseNoteService.createCaseNote(caseUuid, UPDATE_CASE_NOTE_KEY,
-                partyTitle + ": " + existingExternalInterestData.getDetailsOfInterest());
         actionDataExternalInterestRepository.save(existingExternalInterestData);
 
         auditClient.updateExternalInterestAudit(existingExternalInterestData);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -49,23 +49,7 @@ import static uk.gov.digital.ho.hocs.casework.application.LogEvent.PRIMARY_CORRE
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.PRIMARY_TOPIC_UPDATED;
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.STAGE_DEADLINE_UPDATED;
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.UNCAUGHT_EXCEPTION;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.APPEAL_UPDATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.APPEAL_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.EXTENSION_APPLIED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CASE_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CASE_TOPIC_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CASE_TOPIC_DELETED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CASE_UPDATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CORRESPONDENT_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CORRESPONDENT_DELETED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.CORRESPONDENT_UPDATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.DOCUMENT_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.DOCUMENT_DELETED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_ALLOCATED_TO_TEAM;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_ALLOCATED_TO_USER;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_COMPLETED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_CREATED;
-import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.STAGE_RECREATED;
+import static uk.gov.digital.ho.hocs.casework.client.auditclient.EventType.*;
 
 @Service
 @Slf4j
@@ -114,7 +98,10 @@ public class CaseDataService {
             DOCUMENT_DELETED.toString(),
             APPEAL_UPDATED.toString(),
             APPEAL_CREATED.toString(),
-            EXTENSION_APPLIED.toString()
+            EXTENSION_APPLIED.toString(),
+            EXTERNAL_INTEREST_CREATED.toString(),
+            EXTERNAL_INTEREST_UPDATED.toString()
+
     );
 
     public CaseData getCase(UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -393,6 +393,7 @@ public class AuditClient {
                 actionDataExternalInterest.getCaseDataUuid(),
                 actionDataExternalInterest.getCaseDataType(),
                 actionDataExternalInterest.getDetailsOfInterest(),
+                actionDataExternalInterest.getPartyType(),
                 EventType.EXTERNAL_INTEREST_UPDATED
         ));
     }
@@ -403,6 +404,7 @@ public class AuditClient {
                 actionDataExternalInterest.getCaseDataUuid(),
                 actionDataExternalInterest.getCaseDataType(),
                 actionDataExternalInterest.getDetailsOfInterest(),
+                actionDataExternalInterest.getPartyType(),
                 EventType.EXTERNAL_INTEREST_CREATED
         ));
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
@@ -297,6 +297,7 @@ public interface AuditPayload {
         private UUID caseDataUuid;
         private String caseType;
         private String interestDetails;
+        private String partyType;
         private EventType eventType;
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataAppealsServiceTest.java
@@ -53,9 +53,6 @@ public class ActionDataAppealsServiceTest {
     private AuditClient mockAuditClient;
 
     @Mock
-    private CaseNoteService mockCaseNoteService;
-
-    @Mock
     private ObjectMapper mockObjectMapper;
 
     @Captor
@@ -87,8 +84,7 @@ public class ActionDataAppealsServiceTest {
                 mockAppealRepository,
                 mockCaseDataRepository,
                 mockInfoClient,
-                mockAuditClient,
-                mockCaseNoteService
+                mockAuditClient
         );
     }
 
@@ -234,7 +230,6 @@ public class ActionDataAppealsServiceTest {
         assertThat(appealUuid).isEqualTo(createdActionDataAppeal.getUuid());
 
         verify(mockCaseDataRepository, times(1)).findActiveByUuid(caseUUID);
-        verify(mockCaseNoteService, times(1)).createCaseNote(eq(caseUUID), eq("APPEAL_CREATED"), anyString());
         verify(mockAuditClient, times(1)).createAppealAudit(any(), any());
     }
 
@@ -497,7 +492,6 @@ public class ActionDataAppealsServiceTest {
 
         verify(mockInfoClient, times(1)).getCaseTypeActionByUuid(eq(caseData.getType()), eq(actionTypeUuid));
         verify(mockAuditClient, times(1)).updateAppealAudit(any(), any());
-        verify(mockCaseNoteService, times(1)).createCaseNote(eq(caseUUID), eq("APPEAL_UPDATED"), eq(actionTypeLabel));
 
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestServiceTest.java
@@ -84,8 +84,7 @@ public class ActionDataExternalInterestServiceTest {
                 mockExternalInterestRepository,
                 mockCaseDataRepository,
                 mockInfoClient,
-                mockAuditClient,
-                mockCaseNoteService
+                mockAuditClient
         );
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/ActionDataExternalInterestServiceTest.java
@@ -49,9 +49,6 @@ public class ActionDataExternalInterestServiceTest {
     @Mock
     private AuditClient mockAuditClient;
 
-    @Mock
-    private CaseNoteService mockCaseNoteService;
-
     @Captor
     private ArgumentCaptor<ActionDataExternalInterest> externalInterestArgumentCaptor
             = ArgumentCaptor.forClass(ActionDataExternalInterest.class);
@@ -205,7 +202,6 @@ public class ActionDataExternalInterestServiceTest {
         assertThat(externalInterestArgumentCaptor.getValue().getCaseTypeActionUuid()).isEqualTo(actionTypeUuid);
 
         verify(mockCaseDataRepository, times(1)).findActiveByUuid(caseUUID);
-        verify(mockCaseNoteService, times(1)).createCaseNote(eq(caseUUID), eq("RECORD_INTEREST"), anyString());
         verify(mockAuditClient, times(1)).createExternalInterestAudit(any());
     }
 
@@ -315,7 +311,5 @@ public class ActionDataExternalInterestServiceTest {
 
         verify(mockInfoClient, times(1)).getCaseTypeActionByUuid(eq(caseData.getType()), eq(actionTypeUuid));
         verify(mockAuditClient, times(1)).updateExternalInterestAudit(any());
-        verify(mockCaseNoteService, times(1)).createCaseNote(eq(caseUUID), eq("UPDATE_INTEREST"), eq("Test Part Type Changed: TEST_DETAILS_CHANGED"));
-
     }
 }


### PR DESCRIPTION
* Stop saving case notes for actions
* Rely on the audit timeline for action notes