### PR TITLE
Improve Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 version: 2
 updates:
-    - package-ecosystem: "gradle"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      pull-request-branch-name:
-        separator: "-"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"


### PR DESCRIPTION
This change adds a default reviewer of the `UKHomeOffice/hocs-core` that
holds the developers from the core team that will likely oversee package
upgrades. This change also adds the prefix '⬆' before the tickets to
easily identify package upgrades.