### PR TITLE
♻️ HOCS-4383: Create a SearchService

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SearchResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SearchResource.java
@@ -1,0 +1,33 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetStagesResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import javax.validation.Valid;
+import java.util.Set;
+
+@Slf4j
+@RestController
+class SearchResource {
+
+    private final SearchService searchService;
+
+    @Autowired
+    public SearchResource(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @PostMapping(value = "/search")
+    ResponseEntity<GetStagesResponse> search(@Valid @RequestBody SearchRequest request) {
+        Set<StageWithCaseData> stages = searchService.search(request);
+        return ResponseEntity.ok(GetStagesResponse.from(stages));
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SearchService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SearchService.java
@@ -1,0 +1,103 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
+import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
+import uk.gov.digital.ho.hocs.casework.client.searchclient.SearchClient;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SEARCH_STAGE_LIST_EMPTY;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SEARCH_STAGE_LIST_RETRIEVED;
+
+@Slf4j
+@Service
+public class SearchService {
+
+    private final StageService stageService;
+    private final SearchClient searchClient;
+    private final InfoClient infoClient;
+
+    private static final Comparator<StageWithCaseData> CREATED_COMPARATOR = Comparator.comparing(StageWithCaseData::getCreated);
+
+    @Autowired
+    public SearchService(StageService stageService,
+                         SearchClient searchClient,
+                         InfoClient infoClient) {
+        this.stageService = stageService;
+        this.searchClient = searchClient;
+        this.infoClient = infoClient;
+    }
+
+    public Set<StageWithCaseData> search(SearchRequest searchRequest) {
+        log.debug("Getting Stages for Search Request");
+        Set<UUID> caseUUIDs = searchClient.search(searchRequest);
+        if (caseUUIDs.isEmpty()) {
+            log.info("No cases - Returning 0 Stages", value(EVENT, SEARCH_STAGE_LIST_EMPTY));
+            return new HashSet<>(0);
+        }
+
+        Set<StageWithCaseData> stages = stageService.getAllStagesByCaseUUIDIn(caseUUIDs);
+
+        // done like this because the case relationship is in the info schema
+        // get the case types with a previous case type and reduce to
+        // Map<K, V>, - K is the previousCaseType, V is the caseType
+        Map<String, String> caseTypes = infoClient.getAllCaseTypes()
+                .stream()
+                .filter( caseType -> Objects.nonNull(caseType.getPreviousCaseType()))
+                .collect(Collectors.toMap(CaseDataType::getPreviousCaseType, CaseDataType::getDisplayCode));
+
+        // map the previous case type on to the cases found
+        // only stages with completed cases have the next caseType
+        stages.stream()
+                .filter(StageWithCaseData::getCompleted)
+                .forEach(stage -> stage.setNextCaseType(caseTypes.get(stage.getCaseDataType())));
+
+        log.info("Returning {} Stages", stages.size(), value(EVENT, SEARCH_STAGE_LIST_RETRIEVED));
+        return groupByCaseUUID(stages);
+
+    }
+
+    public static Set<StageWithCaseData> reduceToMostActive(Set<StageWithCaseData> stages) {
+        return reduceToMostActive(new ArrayList<>(stages)).collect(Collectors.toSet());
+    }
+
+    private static Set<StageWithCaseData> groupByCaseUUID(Set<? extends StageWithCaseData> stages) {
+
+        // Group the stages by case UUID
+        Map<UUID, List<StageWithCaseData>> groupedStages = stages.stream().collect(Collectors.groupingBy(StageWithCaseData::getCaseUUID));
+
+        // for each of the entry sets, filter out none-active stages, unless there are no active stages then use the latest stage
+        return groupedStages.entrySet().stream().flatMap(s -> reduceToMostActive(s.getValue())).collect(Collectors.toSet());
+    }
+
+    private static Stream<StageWithCaseData> reduceToMostActive(List<StageWithCaseData> stages) {
+        Supplier<Stream<StageWithCaseData>> stageSupplier = stages::stream;
+
+        // If any stages are active
+        if (stageSupplier.get().anyMatch(StageWithCaseData::isActive)) {
+            return stageSupplier.get().filter(StageWithCaseData::isActive);
+        } else {
+            // return the most recent stage.
+            Optional<StageWithCaseData> maxDatedStage = stageSupplier.get().max(CREATED_COMPARATOR);
+            return maxDatedStage.stream();
+        }
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -16,7 +16,6 @@ import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.GetStageResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.GetStagesResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.RecreateStageRequest;
-import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageTeamRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageUserRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.WithdrawCaseRequest;
@@ -30,7 +29,6 @@ import uk.gov.digital.ho.hocs.casework.security.Allocated;
 import uk.gov.digital.ho.hocs.casework.security.AllocationLevel;
 import uk.gov.digital.ho.hocs.casework.security.Authorised;
 
-import javax.validation.Valid;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -161,12 +159,6 @@ class StageResource {
     ResponseEntity<Set<UUID>> getActiveStageCaseUUIDsForUserAndTeam(@PathVariable UUID userUUID, @PathVariable UUID teamUUID) {
         Set<UUID> caseUUIDs = stageService.getActiveStageCaseUUIDsForUserAndTeam(userUUID, teamUUID);
         return ResponseEntity.ok(caseUUIDs);
-    }
-
-    @PostMapping(value = "/search")
-    ResponseEntity<GetStagesResponse> search(@Valid @RequestBody SearchRequest request) {
-        Set<StageWithCaseData> stages = stageService.search(request);
-        return ResponseEntity.ok(GetStagesResponse.from(stages));
     }
 
     @GetMapping(value = "/stage/case/{caseUUID}")

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/SearchResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/SearchResourceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetStagesResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(SearchResource.class)
+@RunWith(SpringRunner.class)
+public class SearchResourceTest {
+
+    @MockBean
+    private SearchService searchService;
+
+    private SearchResource searchResource;
+
+    @Before
+    public void setUp() {
+        searchResource = new SearchResource(searchService);
+    }
+
+    @Test
+    public void shouldSearch() {
+
+        Set<StageWithCaseData> stages = new HashSet<>();
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchService.search(searchRequest)).thenReturn(stages);
+
+        ResponseEntity<GetStagesResponse> response = searchResource.search(searchRequest);
+
+        verify(searchService).search(searchRequest);
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private void checkNoMoreInteractions() {
+        verifyNoMoreInteractions(searchService);
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/SearchServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/SearchServiceTest.java
@@ -1,0 +1,199 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
+import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
+import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
+import uk.gov.digital.ho.hocs.casework.client.searchclient.SearchClient;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@ActiveProfiles("local")
+public class SearchServiceTest {
+
+    private final UUID caseUUID = UUID.randomUUID();
+    private final UUID teamUUID = UUID.randomUUID();
+    private final UUID userUUID = UUID.randomUUID();
+    private final UUID transitionNoteUUID = UUID.randomUUID();
+    private final CaseDataType caseDataType = new CaseDataType("MIN", "1a", "MIN", null);
+    private final List<CaseDataType> caseDataTypes = List.of(
+            CaseDataTypeFactory.from("NXT", "a5", "MIN"), // NXT can be reached through MIN
+                caseDataType);
+
+
+    private SearchService searchService;
+
+    @Mock
+    private SearchClient searchClient;
+    @Mock
+    private InfoClient infoClient;
+    @Mock
+    private StageService stageService;
+
+
+    @Before
+    public void setUp() {
+        this.searchService = new SearchService(stageService, searchClient, infoClient);
+    }
+
+    @Test
+    public void shouldSearch() {
+
+        Set<UUID> caseUUIDS = new HashSet<>();
+        caseUUIDS.add(caseUUID);
+
+        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        Set<StageWithCaseData> stages = new HashSet<>();
+        stages.add(stage);
+
+
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
+        when(stageService.getAllStagesByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+
+        Set<StageWithCaseData> stageResults = searchService.search(searchRequest);
+
+        verify(searchClient).search(searchRequest);
+        verify(stageService).getAllStagesByCaseUUIDIn(caseUUIDS);
+        verifyNoMoreInteractions(searchClient);
+        verifyNoMoreInteractions(stageService);
+
+        assertThat(stageResults).hasSize(1);
+
+    }
+
+    @Test
+    public void shouldSearchCaseAndNextCaseTypesPresent() {
+        StageWithCaseData stageFound = testCaseWithNextCaseType(Boolean.TRUE);
+        assertThat(stageFound.getNextCaseType()).isNotBlank();
+    }
+
+    @Test
+    public void shouldSearchIncompleteCaseAndNextCaseTypesPresent() {
+        StageWithCaseData stageFound = testCaseWithNextCaseType(Boolean.FALSE);
+        assertThat(stageFound.getNextCaseType()).isNull();
+    }
+
+    private StageWithCaseData testCaseWithNextCaseType(Boolean completeCase) {
+
+        // given
+        Set<UUID> caseUUIDS = Set.of(caseUUID);
+        StageWithCaseData repositoryStage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        repositoryStage.setCompleted(completeCase);
+        repositoryStage.setCaseDataType("MIN");
+
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
+        when(stageService.getAllStagesByCaseUUIDIn(caseUUIDS)).thenReturn(Set.of(repositoryStage));
+
+        when(infoClient.getAllCaseTypes()).thenReturn(caseDataTypes);
+
+        // when
+        Set<StageWithCaseData> stageResults = searchService.search(searchRequest);
+
+        // then
+        verify(searchClient).search(searchRequest);
+        verify(stageService).getAllStagesByCaseUUIDIn(caseUUIDS);
+        verifyNoMoreInteractions(searchClient);
+        verifyNoMoreInteractions(stageService);
+
+        assertThat(stageResults).hasSize(1);
+
+        return stageResults.iterator().next();
+
+    }
+
+    @Test
+    public void shouldSearchInactiveStage() {
+
+        Set<UUID> caseUUIDS = new HashSet<>();
+        caseUUIDS.add(caseUUID);
+
+        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        StageWithCaseData stage_old = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", null, null, transitionNoteUUID);
+        Set<StageWithCaseData> stages = new HashSet<>();
+        stages.add(stage);
+        stages.add(stage_old);
+
+
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
+        when(stageService.getAllStagesByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+
+        Set<StageWithCaseData> stageResults = searchService.search(searchRequest);
+
+        verify(searchClient).search(searchRequest);
+        verify(stageService).getAllStagesByCaseUUIDIn(caseUUIDS);
+        verifyNoMoreInteractions(searchClient);
+        verifyNoMoreInteractions(stageService);
+
+        assertThat(stageResults).hasSize(1);
+
+    }
+
+    @Test
+    public void shouldSearchMultipleStages() {
+
+        Set<UUID> caseUUIDS = new HashSet<>();
+        caseUUIDS.add(caseUUID);
+
+        StageWithCaseData stage = new StageWithCaseData(caseUUID, "DCU_MIN_MARKUP", teamUUID, userUUID, transitionNoteUUID);
+        StageWithCaseData stage_old = new StageWithCaseData(UUID.randomUUID(), "DCU_MIN_MARKUP", null, null, transitionNoteUUID);
+        Set<StageWithCaseData> stages = new HashSet<>();
+        stages.add(stage);
+        stages.add(stage_old);
+
+
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
+        when(stageService.getAllStagesByCaseUUIDIn(caseUUIDS)).thenReturn(stages);
+
+        Set<StageWithCaseData> stageResults = searchService.search(searchRequest);
+
+        verify(searchClient).search(searchRequest);
+        verify(stageService).getAllStagesByCaseUUIDIn(caseUUIDS);
+        verifyNoMoreInteractions(searchClient);
+        verifyNoMoreInteractions(stageService);
+
+        assertThat(stageResults).hasSize(2);
+
+    }
+
+    @Test
+    public void shouldSearchNoResults() {
+
+        Set<UUID> caseUUIDS = new HashSet<>(0);
+
+        SearchRequest searchRequest = new SearchRequest();
+
+        when(searchClient.search(searchRequest)).thenReturn(caseUUIDS);
+
+        searchService.search(searchRequest);
+
+        verify(searchClient).search(searchRequest);
+        verifyNoMoreInteractions(searchClient);
+        verifyNoInteractions(stageService);
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -16,7 +16,6 @@ import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.GetStageResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.GetStagesResponse;
 import uk.gov.digital.ho.hocs.casework.api.dto.RecreateStageRequest;
-import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageUserRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.WithdrawCaseRequest;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
@@ -276,23 +275,6 @@ public class StageResourceTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-    }
-
-    @Test
-    public void shouldSearch() {
-
-        Set<StageWithCaseData> stages = new HashSet<>();
-        SearchRequest searchRequest = new SearchRequest();
-
-        when(stageService.search(searchRequest)).thenReturn(stages);
-
-        ResponseEntity<GetStagesResponse> response = stageResource.search(searchRequest);
-
-        verify(stageService).search(searchRequest);
-        checkNoMoreInteractions();
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test


### PR DESCRIPTION
As part of decoupling our microservices we need to start to use domain objects correctly. 'StageWithCaseData' is not part of the domain, any call that currently returns a 'StageWithCaseData' is 
a smell and should return a Case instead. A 'stage with a case data' is actually a Case as case contains stage.

This PR is a refactor to create a SearchService which initially retrieves data from StageService and later will be changed to use CaseService  without having to change the rest of the code. This code has moved from StageService but no functionality has been changed.