### PR TITLE
♻️ HOCS-4383: Create an emailService

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/EmailService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/EmailService.java
@@ -1,0 +1,57 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.casework.client.notifyclient.NotifyClient;
+import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class EmailService {
+
+    private final NotifyClient notifyClient;
+    private final CaseDataService caseDataService;
+
+    @Autowired
+    public EmailService(NotifyClient notifyClient,
+                        CaseDataService caseDataService) {
+        this.notifyClient = notifyClient;
+        this.caseDataService = caseDataService;
+    }
+
+    public void sendTeamEmail(UUID caseUUID, UUID stageUUID, UUID newTeamUUID, String emailType) {
+        CaseData caseData = caseDataService.getCaseInternal(caseUUID);
+        notifyClient.sendTeamEmail(caseUUID, stageUUID, newTeamUUID, caseData.getReference(), emailType);
+    }
+
+    public void sendUserEmail(UUID caseUUID, UUID stageUUID, UUID currentUserUUID, UUID newUserUUID) {
+        CaseData caseData = caseDataService.getCaseInternal(caseUUID);
+        notifyClient.sendUserEmail(caseUUID, stageUUID, currentUserUUID, newUserUUID, caseData.getReference());
+    }
+
+    /*
+    TECH DEBT: This is in the wrong place.
+    This method is checking specific stages and checking for values put in the data by a workflow
+    and should be performed in bpmnService in hocs-workflow as an output of those stages.
+     */
+    public void sendOfflineQAEmail(UUID caseUUID, UUID stageUUID, String stageType, UUID stageUserUUID) {
+        if (stageType.equals(StageWithCaseData.DCU_DTEN_INITIAL_DRAFT) ||
+                stageType.equals(StageWithCaseData.DCU_TRO_INITIAL_DRAFT) ||
+                stageType.equals(StageWithCaseData.DCU_MIN_INITIAL_DRAFT)) {
+
+            if(stageUserUUID != null) {
+                CaseData caseData = caseDataService.getCaseInternal(caseUUID);
+                final String offlineQaUser = caseData.getData(StageWithCaseData.OFFLINE_QA_USER);
+                if (offlineQaUser != null) {
+                    UUID offlineQaUserUUID = UUID.fromString(offlineQaUser);
+                    notifyClient.sendOfflineQaEmail(caseUUID, stageUUID, stageUserUUID, offlineQaUserUUID, caseData.getReference());
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/EmailServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/EmailServiceTest.java
@@ -1,0 +1,99 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.digital.ho.hocs.casework.client.notifyclient.NotifyClient;
+import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData.OFFLINE_QA_USER;
+
+@RunWith(MockitoJUnitRunner.class)
+@ActiveProfiles("local")
+public class EmailServiceTest {
+
+    private final UUID caseUUID = UUID.randomUUID();
+
+    private final UUID stageUUID = UUID.randomUUID();
+
+    private final UUID userUUID = UUID.randomUUID();
+
+    private final UUID offlineUUID = UUID.randomUUID();
+
+    private EmailService emailService;
+
+    @Mock
+    private NotifyClient notifyClient;
+
+    @Mock
+    private CaseDataService caseDataService;
+
+    @Before
+    public void setUp() {
+        this.emailService = new EmailService(notifyClient, caseDataService);
+    }
+
+    @Test
+    public void shouldCheckSendOfflineQAEmail_DTEN() {
+        var caseData = mock(CaseData.class);
+        when(caseData.getReference()).thenReturn("Any Value");
+        when(caseData.getData(OFFLINE_QA_USER)).thenReturn(offlineUUID.toString());
+        when(caseDataService.getCaseInternal(caseUUID)).thenReturn(caseData);
+
+        emailService.sendOfflineQAEmail(caseUUID, stageUUID, StageWithCaseData.DCU_DTEN_INITIAL_DRAFT, userUUID);
+
+        verify(notifyClient).sendOfflineQaEmail(caseUUID, stageUUID, userUUID, offlineUUID, caseData.getReference());
+    }
+
+    @Test
+    public void shouldCheckSendOfflineQAEmail_MIN() {
+        var caseData = mock(CaseData.class);
+        when(caseData.getReference()).thenReturn("Any Value");
+        when(caseData.getData(OFFLINE_QA_USER)).thenReturn(offlineUUID.toString());
+        when(caseDataService.getCaseInternal(caseUUID)).thenReturn(caseData);
+
+        emailService.sendOfflineQAEmail(caseUUID, stageUUID, StageWithCaseData.DCU_MIN_INITIAL_DRAFT, userUUID);
+
+        verify(notifyClient).sendOfflineQaEmail(caseUUID, stageUUID, userUUID, offlineUUID, caseData.getReference());
+    }
+
+    @Test
+    public void shouldCheckSendOfflineQAEmail_TRO() {
+        var caseData = mock(CaseData.class);
+        when(caseData.getReference()).thenReturn("Any Value");
+        when(caseData.getData(OFFLINE_QA_USER)).thenReturn(offlineUUID.toString());
+        when(caseDataService.getCaseInternal(caseUUID)).thenReturn(caseData);
+
+        emailService.sendOfflineQAEmail(caseUUID, stageUUID, StageWithCaseData.DCU_TRO_INITIAL_DRAFT, userUUID);
+
+        verify(notifyClient).sendOfflineQaEmail(caseUUID, stageUUID, userUUID, offlineUUID, caseData.getReference());
+    }
+
+    @Test
+    public void shouldCheckSendOfflineQAEmail_NullCurrentUser() {
+        emailService.sendOfflineQAEmail(caseUUID, stageUUID, StageWithCaseData.DCU_DTEN_INITIAL_DRAFT, null);
+
+        verifyNoInteractions(notifyClient);
+    }
+
+    @Test
+    public void shouldCheckSendOfflineQAEmail_NoOfflineUser() {
+        var caseData = mock(CaseData.class);
+        when(caseDataService.getCaseInternal(caseUUID)).thenReturn(caseData);
+
+        emailService.sendOfflineQAEmail(caseUUID, stageUUID, StageWithCaseData.DCU_DTEN_INITIAL_DRAFT, userUUID);
+
+        verifyNoInteractions(notifyClient);
+    }
+
+}


### PR DESCRIPTION
This PR is a refactor to:
1) Create an Email Service to remove some unrelated activities from StageService.
2) Remove needless audit service access in 'updateStageTeam' when the data we want is available on the stage object we're operating on.
3) Replace 'stageWithCaseData' use with 'stage' use to avoid expensive database call
4) Use 'getCaseInternal' to cut down on audit spam - we shouldn't be auditing internal access of data when we 'getCase' - only when it is requested by the user.