### PR TITLE
Dependabot: ignore aws-java-sdk-sns patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
       separator: "-"
     reviewers:
       - "UKHomeOffice/hocs-core"
+    ignore:
+      - dependency-name: "com.amazonaws:aws-java-sdk-sns"
+        update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
Update to the dependabot configuration to ignore the patch versions for
the aws java library used. This library is used every day as a BOM with
all services. This leads to dependabot changes daily that aren't
required. We ignore the patch versions (excluding security issues) to
reduce this overhead.