### PR TITLE
HOCS-4477: add withdrawal reason to case_data 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -540,7 +540,7 @@ public class StageService {
         // map the previous case type on to the cases found
         // only stages with completed cases have the next caseType
         stages.stream()
-                .filter(stage -> stage.getCompleted())
+                .filter(StageWithCaseData::getCompleted)
                 .forEach(stage -> stage.setNextCaseType(caseTypes.get(stage.getCaseDataType())));
 
         log.info("Returning {} Stages", stages.size(), value(EVENT, SEARCH_STAGE_LIST_RETRIEVED));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -597,6 +597,7 @@ public class StageService {
         Map<String, String> data = new HashMap<>();
         data.put("Withdrawn", "True");
         data.put("WithdrawalDate", request.getWithdrawalDate());
+        data.put("WithdrawalReason", request.getNotes());
         data.put(CaseworkConstants.CURRENT_STAGE, "");
 
         caseDataService.updateCaseData(caseUUID, stageUUID, data);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -1196,6 +1196,7 @@ public class StageServiceTest {
         Map<String, String> expectedData = new HashMap<>();
         expectedData.put("Withdrawn", "True");
         expectedData.put("WithdrawalDate", "2010-11-23");
+        expectedData.put("WithdrawalReason", "Note 1");
         expectedData.put("CurrentStage", "");
 
         verify(caseDataService).getCase(caseUUID);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -158,7 +158,7 @@ public class StageServiceTest {
         verify(extensionService).hasExtensions(caseData.getUuid());
         verify(stageRepository, times(3)).save(any(Stage.class));
         verify(caseDataService).updateCaseData(eq(caseData), any(UUID.class), anyMap());
-        verify(infoClient).getTeamForStageType(eq(stageType));
+        verify(infoClient).getTeamForStageType(stageType);
         verify(stageRepository).save(mockExistingStage);
         verify(auditClient).updateStageTeam(mockExistingStage);
 
@@ -1329,7 +1329,7 @@ public class StageServiceTest {
 
         var result = stageService.getStageTeam(caseUuid, stageUuid);
         assertThat(result).isNotNull();
-        assertThat(result.toString()).isEqualTo(teamUUID.toString());
+        assertThat(result.toString()).hasToString(teamUUID.toString());
 
         verify(stageRepository).findBasicStageByCaseUuidAndStageUuid(caseUuid, stageUuid);
 


### PR DESCRIPTION
This change adds the Withdrawal Reason to the case data blob to allow
the propagation into MI reports.