### PR TITLE
HOCS-4724: send final stage completed audit

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -497,13 +497,12 @@ public class CaseDataService {
 
         // Complete final stage if active stage exists
         Optional<Stage> maybeFinalStage = stageRepository.findFirstByTeamUUIDIsNotNullAndCaseUUID(caseUUID);
-
-        if (maybeFinalStage.isPresent()) {
-            Stage finalStage = maybeFinalStage.get();
-            finalStage.setTeam(null);
-            stageRepository.save(finalStage);
-            log.info("Final active stage: {} for case: {}, completed", finalStage.getUuid(), caseUUID, value(EVENT, STAGE_COMPLETED));
-        }
+        maybeFinalStage.ifPresent(stage -> {
+            stage.setTeam(null);
+            stageRepository.save(stage);
+            auditClient.updateStageTeam(stage);
+            log.info("Final active stage: {} for case: {}, completed", stage.getUuid(), caseUUID, value(EVENT, STAGE_COMPLETED));
+        });
 
         if (completed) {
             caseData.update(CaseworkConstants.CURRENT_STAGE, "");

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -929,7 +929,6 @@ public class CaseDataServiceTest {
 
     @Test
     public void shouldCompleteCaseWhenNoFinalActiveStage() {
-
         CaseData caseData = new CaseData(caseType, caseID, deadlineDate);
 
         when(stageRepository.findFirstByTeamUUIDIsNotNullAndCaseUUID(caseData.getUuid())).thenReturn(Optional.empty());
@@ -943,13 +942,13 @@ public class CaseDataServiceTest {
 
         // Not invoked
         verify(stageRepository, times(0)).save(any(Stage.class));
+        verify(auditClient, times(0)).updateStageTeam(any(Stage.class));
 
         verifyNoMoreInteractions(caseDataRepository, stageRepository);
     }
 
     @Test
     public void shouldCompleteStageAndCaseWhenFinalActiveStage() {
-
         CaseData caseData = new CaseData(caseType, caseID, deadlineDate);
 
         Stage mockStage = new Stage(caseData.getUuid(), "RANDOM_STAGE_TYPE",UUID.randomUUID(),UUID.randomUUID(),UUID.randomUUID());
@@ -964,6 +963,7 @@ public class CaseDataServiceTest {
         verify(caseDataRepository, times(1)).save(caseData);
         verify(stageRepository, times(1)).findFirstByTeamUUIDIsNotNullAndCaseUUID(any(UUID.class));
         verify(stageRepository, times(1)).save(any(Stage.class));
+        verify(auditClient).updateStageTeam(any(Stage.class));
 
         verifyNoMoreInteractions(caseDataRepository, stageRepository);
     }


### PR DESCRIPTION
When a case is at the end of a workflow, when completing a case we don't
send a STAGE_COMPLETED audit line for that stage. This change triggers
this audit event when a case is completed with an active stage.