### PR TITLE
HOCS-4696: Remove duplicate Sonar Run.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,13 +191,6 @@ steps:
     depends_on:
       - setup localstack
 
-  - name: sonar scanner
-    image: quay.io/ukhomeofficedigital/sonar-scanner
-    commands:
-      - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
-    depends_on:
-      - test project
-
   - name: build & push
     image: plugins/docker
     settings:


### PR DESCRIPTION
Sonar is already run on a push event, so doesn't need to run again on tag against the same code.