### PR TITLE
HOCS-4696: Override Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     ignore:
       - dependency-name: "com.amazonaws:aws-java-sdk-sns"
         update-types: [ "version-update:semver-patch" ]
+    labels:
+      - "patch"
+      - "dependencies"


### PR DESCRIPTION
Since adding the semver labels Dependabot has been adding 'Major', 'Minor' or 'Patch' labels on its PRs according the semver bump on the library it is updating.
We want it to add 'patch' regardless as from our perspective the change is a patch change to the service.