### PR TITLE
Fix dependancy issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.amazonaws:aws-java-sdk-sns:1.12.149'
 
-    implementation 'com.vladmihalcea:hibernate-types-52:2.15.1'
+    implementation 'com.vladmihalcea:hibernate-types-55:2.15.1'
     implementation 'com.google.guava:guava:31.1-jre'
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.amazonaws:aws-java-sdk-sns:1.12.149'
+
     implementation 'com.vladmihalcea:hibernate-types-52:2.15.1'
+    implementation 'com.google.guava:guava:31.1-jre'
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
@@ -62,7 +64,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
 }
 
 dependencyManagement {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,7 @@ spring.datasource.hikari.minimumIdle=20
 spring.flyway.locations=classpath:/db/migration/postgresql
 spring.flyway.schemas=${db.schema.name:casework}
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+spring.jpa.properties.hibernate.types.print.banner=false
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 hocs.info-service=http://localhost:8085


### PR DESCRIPTION
The latest 2.15.1 version of the `hibernate-types` requires the 'Range'
class of Guava (which it does not provide). As we have Guava in our test
dependencies this change passes current tests. Changing this to a
general `implementation` gives runtime access to the library.

We use `hibernate-types-52` which is suitable for Hibernate
`5.4, 5.3, 5.2`. The hibernate library is currently 5.6.7 which doesn't
have a hibernate-types library. This change upgrades to the closest
match for the time being.