### PR TITLE
HOCS-4980: pass the created date to timeline lookup

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -672,7 +672,7 @@ public class CaseDataService {
         CaseData caseData = getCaseData(caseUUID);
         Set<GetAuditResponse> audit = new HashSet<>();
         try {
-            audit.addAll(auditClient.getAuditLinesForCase(caseUUID, TIMELINE_EVENTS));
+            audit.addAll(auditClient.getAuditLinesForCase(caseUUID, caseData.getCreated().toLocalDate(), TIMELINE_EVENTS));
             log.debug("Retrieved {} audit lines", audit.size());
         } catch (Exception e) {
             log.error("Failed to retrieve audit lines for case {}", caseUUID, value(EVENT, AUDIT_CLIENT_GET_AUDITS_FOR_CASE_FAILURE), value(EXCEPTION, e));

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -33,6 +33,7 @@ import uk.gov.digital.ho.hocs.casework.domain.model.SomuItem;
 import uk.gov.digital.ho.hocs.casework.domain.model.Topic;
 import uk.gov.digital.ho.hocs.casework.util.SnsStringMessageAttributeValue;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -547,6 +548,18 @@ public class AuditClient {
         try {
             String events = String.join(",", requestedEvents);
             GetAuditListResponse response = restHelper.get(serviceBaseURL, String.format("/audit/case/%s?types=%s", caseUUID, events), GetAuditListResponse.class);
+            log.info("Got {} audits", response.getAudits().size(), value(LogEvent.EVENT, LogEvent.AUDIT_CLIENT_GET_AUDITS_FOR_CASE_SUCCESS));
+            return response.getAudits();
+        } catch (RestClientException e) {
+            log.error("Could not get audit lines, event {}, exception: {}", value(LogEvent.EVENT, LogEvent.AUDIT_CLIENT_GET_AUDITS_FOR_CASE_FAILURE), value(LogEvent.EXCEPTION, e));
+            return new HashSet<>();
+        }
+    }
+
+    public Set<GetAuditResponse> getAuditLinesForCase(UUID caseUUID, LocalDate fromDate, List<String> requestedEvents) {
+        try {
+            String events = String.join(",", requestedEvents);
+            GetAuditListResponse response = restHelper.get(serviceBaseURL, String.format("/audit/case/%s?fromDate=%s&types=%s", caseUUID, fromDate, events), GetAuditListResponse.class);
             log.info("Got {} audits", response.getAudits().size(), value(LogEvent.EVENT, LogEvent.AUDIT_CLIENT_GET_AUDITS_FOR_CASE_SUCCESS));
             return response.getAudits();
         } catch (RestClientException e) {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -485,7 +485,7 @@ public class CaseDataServiceTest {
 
 
         when(caseDataRepository.findActiveByUuid(caseData.getUuid())).thenReturn(caseData);
-        when(auditClient.getAuditLinesForCase(eq(caseData.getUuid()), any())).thenThrow(new RuntimeException("Error"));
+        when(auditClient.getAuditLinesForCase(eq(caseData.getUuid()), any(), any())).thenThrow(new RuntimeException("Error"));
 
         List<TimelineItem> timeline = caseDataService.getCaseTimeline(caseData.getUuid()).collect(Collectors.toList());
 
@@ -495,7 +495,7 @@ public class CaseDataServiceTest {
         assertThat(timeline).anyMatch(t -> t.getMessage().contains("case note 1"));
         assertThat(timeline).noneMatch(t -> t.getType().equals(CASE_CREATED.toString()));
 
-        verify(auditClient, times(1)).getAuditLinesForCase(eq(caseData.getUuid()), any());
+        verify(auditClient, times(1)).getAuditLinesForCase(eq(caseData.getUuid()), any(), any());
         verifyNoMoreInteractions(auditClient);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -459,7 +459,7 @@ public class CaseDataServiceTest {
 
 
         when(caseDataRepository.findActiveByUuid(caseData.getUuid())).thenReturn(caseData);
-        when(auditClient.getAuditLinesForCase(eq(caseData.getUuid()), any())).thenReturn(auditResponse);
+        when(auditClient.getAuditLinesForCase(eq(caseData.getUuid()), any(), any())).thenReturn(auditResponse);
 
         List<TimelineItem> timeline = caseDataService.getCaseTimeline(caseData.getUuid()).collect(Collectors.toList());
 
@@ -470,7 +470,7 @@ public class CaseDataServiceTest {
         assertThat(timeline).anyMatch(t -> t.getMessage().contains("case note 1"));
         assertThat(timeline).anyMatch(t -> t.getType().equals(CASE_CREATED.toString()));
 
-        verify(auditClient, times(1)).getAuditLinesForCase(eq(caseData.getUuid()), any());
+        verify(auditClient, times(1)).getAuditLinesForCase(eq(caseData.getUuid()), any(), any());
         verifyNoMoreInteractions(auditClient);
     }
 


### PR DESCRIPTION
HOCS-4980: pass the created date to allow audit service not to search table partitions for audit events before the case was created.