### PR TITLE
HOCS-5354: remove CASE_TYPE_MARKER

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImpl.java
@@ -24,7 +24,6 @@ public class StagePriorityCalculatorImpl implements StagePriorityCalculator {
             priority += policy.apply(stageWithCaseData);
         }
 
-        caseData.put(StagePriorityPolicy.CASE_TYPE, caseType);
         caseData.put(SYSTEM_PRIORITY_FIELD_NAME, String.valueOf(priority));
 
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/StagePriorityPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/StagePriorityPolicy.java
@@ -3,7 +3,5 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
 
 public interface StagePriorityPolicy {
-    String CASE_TYPE = "CASE_TYPE_MARKER";
-
     double apply(StageWithCaseData data);
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicy.java
@@ -37,7 +37,7 @@ public class WorkingDaysElapsedPolicy implements StagePriorityPolicy {
         if (StringUtils.hasText(dateString)) {
             LocalDate dateToCheck = LocalDate.parse(dateString, DateTimeFormatter.ofPattern(dateFormat));
 
-            int daysElapsed = workingDaysElapsedProvider.getWorkingDaysSince(data.get(CASE_TYPE), dateToCheck);
+            int daysElapsed = workingDaysElapsedProvider.getWorkingDaysSince(stageWithCaseData.getCaseDataType(), dateToCheck);
             if (capNumberOfDays > -1 && daysElapsed >= capNumberOfDays) {
                 return capPointsToAward;
             }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImplTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImplTest.java
@@ -32,6 +32,8 @@ public class StagePriorityCalculatorImplTest {
         stagePriorityCalculator = new StagePriorityCalculatorImpl(stagePriorityPolicyProvider);
 
         stage = new StageWithCaseData();
+        stage.setCaseDataType(caseType);
+
     }
 
     @Test
@@ -47,7 +49,6 @@ public class StagePriorityCalculatorImplTest {
     @Test
     public void updatePriority_withPolicies(){
         stage.putData("PropertyA", "ValueA");
-        stage.putData(StagePriorityPolicy.CASE_TYPE, caseType);
 
         StagePriorityPolicy policyA = mock(StagePriorityPolicy.class);
         when(policyA.apply(stage)).thenReturn(12d);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicyTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicyTest.java
@@ -10,11 +10,9 @@ import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static uk.gov.digital.ho.hocs.casework.priority.policy.StagePriorityPolicy.CASE_TYPE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WorkingDaysElapsedPolicyTest {
@@ -38,6 +36,7 @@ public class WorkingDaysElapsedPolicyTest {
     @Before
     public void before() {
         stage = new StageWithCaseData();
+        stage.setCaseDataType(TEST_CASE_TYPE);
 
         policy = new WorkingDaysElapsedPolicy(workingDaysElapsedProvider, PROPERTY_NAME, PROPERTY_VALUE, DATE_FIELD_NAME, DATE_FORMAT, CAP_NUMBER_OF_DAYS,
                 CAP_POINTS_TO_AWARD, POINTS_TO_AWARD_PER_DAY);
@@ -49,7 +48,6 @@ public class WorkingDaysElapsedPolicyTest {
 
         when(workingDaysElapsedProvider.getWorkingDaysSince(TEST_CASE_TYPE, testDate)).thenReturn(10);
 
-        stage.putData(CASE_TYPE, TEST_CASE_TYPE);
         stage.putData(PROPERTY_NAME, PROPERTY_VALUE);
         stage.putData(DATE_FIELD_NAME, DateTimeFormatter.ofPattern(DATE_FORMAT).format(testDate));
 
@@ -66,7 +64,6 @@ public class WorkingDaysElapsedPolicyTest {
 
         when(workingDaysElapsedProvider.getWorkingDaysSince(TEST_CASE_TYPE, testDate)).thenReturn(55);
 
-        stage.putData(CASE_TYPE, TEST_CASE_TYPE);
         stage.putData(PROPERTY_NAME, PROPERTY_VALUE);
         stage.putData(DATE_FIELD_NAME, DateTimeFormatter.ofPattern(DATE_FORMAT).format(testDate));
 


### PR DESCRIPTION
Previously there was a necessary case type marker that was added to the
case data blob during priority calculation that allowed for exemption
dates to be returned. As the whole StageWithCaseData object is passed
now, the case type is available in the resultant call. Therefore, this
marker is no longer required and has been removed.