### PR TITLE
HOCS-5363: serve tabs from frontend

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -223,4 +223,10 @@ class CaseDataResource {
         final String caseRef = caseDataService.getCaseRef(caseUUID);
         return ResponseEntity.ok(GetCaseReferenceResponse.from(caseUUID, caseRef));
     }
+
+    @GetMapping(value = "/case/{caseUUID}/type")
+    public ResponseEntity<GetCaseTypeResponse> getCaseTypeForCase(@PathVariable UUID caseUUID) {
+        String caseRef = caseDataService.getCaseType(caseUUID);
+        return ResponseEntity.ok(GetCaseTypeResponse.from(caseRef));
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -78,6 +78,7 @@ class CaseDataResource {
         return ResponseEntity.ok(GetCaseSummaryResponse.from(caseSummary));
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping(value = "/case/{caseUUID}/config")
     public ResponseEntity<GetCaseConfigResponse> getCaseConfig(@PathVariable UUID caseUUID) {
         CaseConfig caseConfig = caseDataService.getCaseConfig(caseUUID);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -595,6 +595,7 @@ public class CaseDataService {
         return builtCaseSummary;
     }
 
+    @Deprecated(forRemoval = true)
     CaseConfig getCaseConfig(UUID caseUUID) {
         String caseType = caseDataRepository.getCaseType(caseUUID);
         return infoClient.getCaseConfig(caseType);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseConfigResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseConfigResponse.java
@@ -9,6 +9,7 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseTab;
 
 import java.util.List;
 
+@Deprecated(forRemoval = true)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class GetCaseConfigResponse {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseTypeResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseTypeResponse.java
@@ -1,0 +1,21 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetCaseTypeResponse {
+
+    @JsonProperty("type")
+    private String type;
+
+    public static GetCaseTypeResponse from(String type) {
+        return new GetCaseTypeResponse(type);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
@@ -48,6 +48,7 @@ public class InfoClient {
         return caseDataType;
     }
 
+    @Deprecated(forRemoval = true)
     @Cacheable(value = "InfoClientGetCaseConfig", unless = "#result == null", key = "#type")
     public CaseConfig getCaseConfig(String type) {
         CaseConfig caseConfig = restHelper.get(serviceBaseURL, String.format("/caseType/%s/config", type), CaseConfig.class);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseConfig.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseConfig.java
@@ -2,16 +2,12 @@ package uk.gov.digital.ho.hocs.casework.domain.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.casework.api.dto.CaseActionDataResponseDto;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 
 @AllArgsConstructor
 @Getter
+@Deprecated(forRemoval = true)
 public class CaseConfig {
     @Getter
     private final String type;


### PR DESCRIPTION
This changes sets up the ability to remove the serving of case type tabs from hocs-info-service. This is supported through a new enpoint that is used by the frontend to designate the tabs to show from a configuration file. 

As a result the case configuration endpoint and surrounding implementations have been flagged as deprecated for future removal.