### PR TITLE
HOCS-5462: add equals and hash code

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseSummaryResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetCaseSummaryResponse.java
@@ -72,9 +72,9 @@ public class GetCaseSummaryResponse {
             additionalFieldDtos.addAll(caseSummary.getAdditionalFields().stream()
                     .filter(field -> !ObjectUtils.isEmpty(field.getValue()))
                     .map(AdditionalFieldDto::from)
-                    .collect(Collectors.toList()));
+                    .sorted(Comparator.comparing(AdditionalFieldDto::getLabel))
+                    .toList());
         }
-        additionalFieldDtos.sort(Comparator.comparing(AdditionalFieldDto::getLabel));
 
         return new GetCaseSummaryResponse(
                 caseSummary.getType(),

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AdditionalField.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AdditionalField.java
@@ -3,6 +3,8 @@ package uk.gov.digital.ho.hocs.casework.domain.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @AllArgsConstructor
 public class AdditionalField {
 
@@ -20,4 +22,18 @@ public class AdditionalField {
 
     @Getter
     private String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AdditionalField that = (AdditionalField) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
 }


### PR DESCRIPTION
Add Equals and HashCode method to AdditionalField to allow for Sets to
strip duplicates as by default these use the internal memory address
of the object.