### PR TITLE
HOCS-5521: add missing POGR->POGR2 key

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRtoPOGR2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRtoPOGR2.java
@@ -23,6 +23,7 @@ public class CopyPOGRtoPOGR2 extends AbstractCaseCopyStrategy implements CaseCop
             "ComplainantLocation",
             "ComplaintDescription",
             "ComplaintChannel",
+            "ComplaintNationOrigin",
             "ComplaintPriority",
             "ComplaintThirdPartyReference",
             "LoaRequired",


### PR DESCRIPTION
Add missing `ComplaintNationOrigin` key to copy from POGR cases when
escalating to POGR2.