### PR TITLE
HOCS-5575: add POGR2 priority policy

### DIFF
--- a/src/main/resources/config/priority-policies.json
+++ b/src/main/resources/config/priority-policies.json
@@ -74,5 +74,19 @@
       "type": "DeadlinePolicy",
       "config": { }
     }
+  ],
+  "POGR2": [
+    {
+      "type": "SimpleStringPropertyPolicy",
+      "config": {
+        "propertyName": "ComplaintPriority",
+        "pointsToAward": "1000",
+        "propertyValue": "Yes"
+      }
+    },
+    {
+      "type": "DeadlinePolicy",
+      "config": { }
+    }
   ]
 }


### PR DESCRIPTION
Add the POGR2 priority policy configuration. This is the same as the
POGR configuration.