### PR TITLE
HOCS-5629: fix choices for accordion field

### DIFF
--- a/src/main/resources/config/details/stages/IEDET.json
+++ b/src/main/resources/config/details/stages/IEDET.json
@@ -250,7 +250,7 @@
         "component": "entity-list",
         "props": {
           "entity": "document",
-          "choices": "CASE_DOCUMENT_LIST_FINAL_RESPONSE",
+          "choices": "CASE_DOCUMENT_LIST_IEDET_FINAL_RESPONSE",
           "hasAddLink": true,
           "hasRemoveLink": true
         },


### PR DESCRIPTION
Fix the FinalResponseDocument field to ensure that the correct choice is
 used to convert the uuid to the name of the document.