### PR TITLE
HOCS-5679: refactor document tags 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResource.java
@@ -209,13 +209,6 @@ class CaseDataResource {
         return ResponseEntity.ok().build();
     }
 
-    @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
-    @GetMapping(value = "/case/{caseUUID}/documentTags")
-    public ResponseEntity<List<String>> getDocumentTags(@PathVariable UUID caseUUID) {
-        List<String> documentTags = caseDataService.getDocumentTags(caseUUID);
-        return ResponseEntity.ok(documentTags);
-    }
-
     @Authorised(accessLevel = AccessLevel.READ)
     @GetMapping(value = "/case/{caseUUID}/standardLine")
     public ResponseEntity<Set<GetStandardLineResponse>> getStandardLine(@PathVariable UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDataService.java
@@ -656,12 +656,6 @@ public class CaseDataService {
         return stageDeadlines;
     }
 
-    List<String> getDocumentTags(UUID caseUUID) {
-        String caseType = caseDataRepository.getCaseType(caseUUID);
-        List<String> documentTags = infoClient.getDocumentTags(caseType);
-        return documentTags;
-    }
-
     Set<GetStandardLineResponse> getStandardLine(UUID caseUUID) {
         CaseData caseData = getCaseData(caseUUID);
         auditClient.viewStandardLineAudit(caseData);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResource.java
@@ -6,16 +6,20 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.hocs.casework.client.documentclient.DocumentDto;
 import uk.gov.digital.ho.hocs.casework.client.documentclient.GetDocumentsResponse;
 import uk.gov.digital.ho.hocs.casework.client.documentclient.S3Document;
 import uk.gov.digital.ho.hocs.casework.security.AccessLevel;
 import uk.gov.digital.ho.hocs.casework.security.Authorised;
 
+import java.util.List;
 import java.util.UUID;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
@@ -30,7 +34,7 @@ public class CaseDocumentResource {
     }
 
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
-    @GetMapping(value = "/case/document/reference/{caseUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/document/reference/{caseUUID}", produces = APPLICATION_JSON_VALUE)
     ResponseEntity<GetDocumentsResponse> getDocumentsForCase(@PathVariable UUID caseUUID,
                                                              @RequestParam(name = "type", required = false)
                                                              String type) {
@@ -45,14 +49,14 @@ public class CaseDocumentResource {
     }
 
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
-    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<DocumentDto> getDocumentResourceLocation(@PathVariable UUID caseUUID,
                                                                    @PathVariable UUID documentUUID) {
         return ResponseEntity.ok(caseDocumentService.getDocument(documentUUID));
     }
 
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
-    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/file", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/file", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getCaseDocumentFile(@PathVariable UUID caseUUID,
                                                                  @PathVariable UUID documentUUID) {
         S3Document document = caseDocumentService.getDocumentFile(documentUUID);
@@ -66,7 +70,7 @@ public class CaseDocumentResource {
     }
 
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
-    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/pdf", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/pdf", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getCaseDocumentPdf(@PathVariable UUID caseUUID,
                                                                 @PathVariable UUID documentUUID) {
         S3Document document = caseDocumentService.getDocumentPdf(documentUUID);
@@ -78,5 +82,12 @@ public class CaseDocumentResource {
             "attachment;filename=" + document.getOriginalFilename()).contentType(mediaType).contentLength(
             document.getData().length).body(resource);
     }
+
+    @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
+    @GetMapping(value = "/case/{caseUUID}/documentTags", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<String>> getDocumentTags(@PathVariable UUID caseUUID) {
+        return ResponseEntity.ok(caseDocumentService.getDocumentTags(caseUUID));
+    }
+
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseProfileResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseProfileResource.java
@@ -3,7 +3,6 @@ package uk.gov.digital.ho.hocs.casework.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +18,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 @Slf4j
 @RestController
+@Deprecated(forRemoval = true)
 class CaseProfileResource {
 
     private final CaseDataService caseDataService;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClient.java
@@ -171,17 +171,6 @@ public class InfoClient {
         return response;
     }
 
-    @Cacheable(value = "InfoClientGetDocumentTagsRequest",
-               unless = "#result == null or #result.size() == 0",
-               key = "#caseType")
-    public List<String> getDocumentTags(String caseType) {
-        List<String> response = restHelper.get(serviceBaseURL, String.format("/caseType/%s/documentTags", caseType),
-            new ParameterizedTypeReference<List<String>>() {});
-        log.info("Got {} document tags for CaseType {}", response.size(), caseType,
-            value(EVENT, INFO_CLIENT_GET_SUMMARY_FIELDS_SUCCESS));
-        return response;
-    }
-
     @Cacheable(value = "InfoClientGetAllStagesForCaseType", unless = "#result.size() == 0", key = "{#caseType}")
     public Set<StageTypeDto> getAllStagesForCaseType(String caseType) {
         Set<StageTypeDto> response = restHelper.get(serviceBaseURL, String.format("/stages/caseType/%s", caseType),

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseTypeDocumentTags.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseTypeDocumentTags.java
@@ -1,0 +1,31 @@
+package uk.gov.digital.ho.hocs.casework.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.digital.ho.hocs.casework.domain.repository.JsonConfigFolderReader.CaseTypeObject;
+
+import java.util.List;
+
+public class CaseTypeDocumentTags implements CaseTypeObject<List<String>> {
+
+    private final String type;
+    private final List<String> tags;
+
+    @JsonCreator
+    public CaseTypeDocumentTags(@JsonProperty("type") String type,
+                                @JsonProperty("tags") List<String> tags) {
+        this.type = type;
+        this.tags = tags;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public List<String> getValue() {
+        return tags;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseTypeDocumentTagRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseTypeDocumentTagRepository.java
@@ -1,0 +1,44 @@
+package uk.gov.digital.ho.hocs.casework.domain.repository;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.casework.domain.model.CaseTypeDocumentTags;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.CASE_DATA_DETAILS_NOT_FOUND;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.EVENT;
+
+@Service
+@Slf4j
+public class CaseTypeDocumentTagRepository extends JsonConfigFolderReader {
+
+    public final Map<String, List<String>> documentTags;
+
+    public CaseTypeDocumentTagRepository(ObjectMapper objectMapper) {
+        super(objectMapper);
+
+        documentTags = readValueFromFolder(new TypeReference<CaseTypeDocumentTags>() {});
+    }
+
+    public List<String> getTagsByType(String type) {
+        var tags = documentTags.get(type);
+
+        if (tags == null) {
+            log.warn("No mapping found for type: {}", type, value(EVENT, CASE_DATA_DETAILS_NOT_FOUND));
+            return Collections.emptyList();
+        }
+        return tags;
+    }
+
+    @Override
+    String getFolderName() {
+        return "document-tags";
+    }
+
+}

--- a/src/main/resources/config/document-tags/BF.json
+++ b/src/main/resources/config/document-tags/BF.json
@@ -1,0 +1,12 @@
+{
+  "type": "BF",
+  "tags": [
+    "To document",
+    "Public correspondence",
+    "Complaint leaflet",
+    "Complaint letter",
+    "Email",
+    "CRF",
+    "DRAFT"
+  ]
+}

--- a/src/main/resources/config/document-tags/BF2.json
+++ b/src/main/resources/config/document-tags/BF2.json
@@ -1,0 +1,12 @@
+{
+  "type": "BF2",
+  "tags": [
+    "To document",
+    "Public correspondence",
+    "Complaint leaflet",
+    "Complaint letter",
+    "Email",
+    "CRF",
+    "DRAFT"
+  ]
+}

--- a/src/main/resources/config/document-tags/COMP.json
+++ b/src/main/resources/config/document-tags/COMP.json
@@ -1,0 +1,15 @@
+{
+  "type": "COMP",
+  "tags": [
+    "To document",
+    "Public correspondence",
+    "Complaint leaflet",
+    "Complaint letter",
+    "Email",
+    "CRF",
+    "DRAFT",
+    "Appeal Leaflet",
+    "IMB Letter",
+    "Final Response"
+  ]
+}

--- a/src/main/resources/config/document-tags/COMP2.json
+++ b/src/main/resources/config/document-tags/COMP2.json
@@ -1,0 +1,15 @@
+{
+  "type": "COMP2",
+  "tags": [
+    "To document",
+    "Public correspondence",
+    "Complaint leaflet",
+    "Complaint letter",
+    "Email",
+    "CRF",
+    "DRAFT",
+    "Appeal Leaflet",
+    "IMB Letter",
+    "Final Response"
+  ]
+}

--- a/src/main/resources/config/document-tags/DTEN.json
+++ b/src/main/resources/config/document-tags/DTEN.json
@@ -1,0 +1,10 @@
+{
+  "type": "DTEN",
+  "tags": [
+    "ORIGINAL",
+    "DRAFT",
+    "FINAL",
+    "CONTRIBUTION",
+    "BACKGROUND NOTE"
+  ]
+}

--- a/src/main/resources/config/document-tags/FOI.json
+++ b/src/main/resources/config/document-tags/FOI.json
@@ -1,0 +1,15 @@
+{
+  "type": "FOI",
+  "tags": [
+    "Request",
+    "Initial response",
+    "Draft response",
+    "Clearances",
+    "Final responses",
+    "Correspondence",
+    "Contribution",
+    "Miscellaneous",
+    "Appeal Response",
+    "PIT Extension"
+  ]
+}

--- a/src/main/resources/config/document-tags/IEDET.json
+++ b/src/main/resources/config/document-tags/IEDET.json
@@ -1,0 +1,11 @@
+{
+  "type": "IEDET",
+  "tags": [
+    "Original complaint",
+    "Letter of Authority",
+    "Interim response",
+    "Final response",
+    "Withdrawal letter",
+    "Other"
+  ]
+}

--- a/src/main/resources/config/document-tags/MIN.json
+++ b/src/main/resources/config/document-tags/MIN.json
@@ -1,0 +1,10 @@
+{
+  "type": "MIN",
+  "tags": [
+    "ORIGINAL",
+    "DRAFT",
+    "FINAL",
+    "CONTRIBUTION",
+    "BACKGROUND NOTE"
+  ]
+}

--- a/src/main/resources/config/document-tags/MPAM.json
+++ b/src/main/resources/config/document-tags/MPAM.json
@@ -1,0 +1,13 @@
+{
+  "type": "MPAM",
+  "tags": [
+    "Original correspondence",
+    "Further correspondence from MPs Office",
+    "Contributions requested",
+    "Contributions received",
+    "Draft response (includes QA rejected)",
+    "Background note",
+    "Final response",
+    "Additional correspondence (Holding Replies)"
+  ]
+}

--- a/src/main/resources/config/document-tags/MTS.json
+++ b/src/main/resources/config/document-tags/MTS.json
@@ -1,0 +1,12 @@
+{
+  "type": "MTS",
+  "tags": [
+    "Original correspondence",
+    "Further correspondence from MPs Office",
+    "Contributions requested",
+    "Contributions received",
+    "Draft response (includes QA rejected)",
+    "Background note",
+    "Final response"
+  ]
+}

--- a/src/main/resources/config/document-tags/POGR.json
+++ b/src/main/resources/config/document-tags/POGR.json
@@ -1,0 +1,9 @@
+{
+  "type": "POGR",
+  "tags": [
+    "Original Complaint",
+    "Interim Letter",
+    "Draft",
+    "Final Response"
+  ]
+}

--- a/src/main/resources/config/document-tags/POGR2.json
+++ b/src/main/resources/config/document-tags/POGR2.json
@@ -1,0 +1,9 @@
+{
+  "type": "POGR2",
+  "tags": [
+    "Original Complaint",
+    "Interim Letter",
+    "Draft",
+    "Final Response"
+  ]
+}

--- a/src/main/resources/config/document-tags/SMC.json
+++ b/src/main/resources/config/document-tags/SMC.json
@@ -1,0 +1,15 @@
+{
+  "type": "SMC",
+  "tags": [
+    "To document",
+    "Public correspondence",
+    "Complaint leaflet",
+    "Complaint letter",
+    "Email",
+    "CRF",
+    "DRAFT",
+    "Appeal Leaflet",
+    "IMB Letter",
+    "Final Response"
+  ]
+}

--- a/src/main/resources/config/document-tags/TO.json
+++ b/src/main/resources/config/document-tags/TO.json
@@ -1,0 +1,11 @@
+{
+  "type": "TO",
+  "tags": [
+    "Initial Correspondence",
+    "Initial Draft",
+    "Final Response",
+    "Contribution Request",
+    "Contribution Response",
+    "Background Note"
+  ]
+}

--- a/src/main/resources/config/document-tags/TRO.json
+++ b/src/main/resources/config/document-tags/TRO.json
@@ -1,0 +1,10 @@
+{
+  "type": "TRO",
+  "tags": [
+    "ORIGINAL",
+    "DRAFT",
+    "FINAL",
+    "CONTRIBUTION",
+    "BACKGROUND NOTE"
+  ]
+}

--- a/src/main/resources/config/document-tags/WCS.json
+++ b/src/main/resources/config/document-tags/WCS.json
@@ -1,0 +1,9 @@
+{
+  "type": "WCS",
+  "tags": [
+    "Claim form",
+    "Supporting evidence",
+    "Matrix",
+    "Letter sent"
+  ]
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataResourceTest.java
@@ -7,7 +7,22 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.digital.ho.hocs.casework.api.dto.*;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
+import uk.gov.digital.ho.hocs.casework.api.dto.CaseSummaryLink;
+import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCaseResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCaseSummaryResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetCorrespondentResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetTopicResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.MigrateCaseRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.MigrateCaseResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdateCaseDataRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdateDeadlineForStagesRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdatePrimaryCorrespondentRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageDeadlineRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdateTeamByStageAndTextsRequest;
+import uk.gov.digital.ho.hocs.casework.api.dto.UpdateTeamByStageAndTextsResponse;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.domain.model.Address;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
@@ -18,7 +33,6 @@ import uk.gov.digital.ho.hocs.casework.domain.model.Topic;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -298,19 +312,6 @@ public class CaseDataResourceTest {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).isInstanceOf(UpdateTeamByStageAndTextsResponse.class);
         assertThat(response.getBody().getTeamMap()).isEqualTo(teamMap);
-    }
-
-    @Test
-    public void shouldGetDocumentTags() {
-        UUID caseUUID = UUID.randomUUID();
-        List<String> documentTags = List.of("Tag");
-        when(caseDataService.getDocumentTags(caseUUID)).thenReturn(documentTags);
-
-        ResponseEntity<List<String>> response = caseDataResource.getDocumentTags(caseUUID);
-
-        assertThat(response.getBody()).isSameAs(documentTags);
-        verify(caseDataService).getDocumentTags(caseUUID);
-        verifyNoMoreInteractions(caseDataService);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/CaseDataServiceTest.java
@@ -44,7 +44,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -392,22 +391,6 @@ public class CaseDataServiceTest {
         // check audit
         verify(auditClient).migrateCaseAudit(caseData.getValue());
         verifyNoMoreInteractions(auditClient);
-    }
-
-    @Test
-    public void shouldGetDocumentTags() {
-        UUID caseUUID = UUID.randomUUID();
-        when(caseDataRepository.getCaseType(caseUUID)).thenReturn("TEST");
-        List<String> documentTags = new ArrayList<String>(Arrays.asList("Tag"));
-        when(infoClient.getDocumentTags("TEST")).thenReturn(documentTags);
-
-        List<String> tags = caseDataService.getDocumentTags(caseUUID);
-
-        assertThat(tags).isSameAs(documentTags);
-        verify(caseDataRepository).getCaseType(caseUUID);
-        verifyNoMoreInteractions(caseDataRepository);
-        verify(infoClient).getDocumentTags("TEST");
-        verifyNoMoreInteractions(infoClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/client/infoclient/InfoClientTest.java
@@ -124,18 +124,6 @@ public class InfoClientTest {
     }
 
     @Test
-    public void getDocumentTags() {
-        List<String> tags = new ArrayList(Arrays.asList("tag"));
-        when(restHelper.get("infoService", "/caseType/TEST/documentTags",
-            new ParameterizedTypeReference<List<String>>() {})).thenReturn(tags);
-
-        List<String> response = infoClient.getDocumentTags("TEST");
-
-        assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(1);
-    }
-
-    @Test
     public void getEntityListTotalsReturnsEntityList() {
         EntityTotalDto entityTotalDto = new EntityTotalDto(new HashMap(), new HashMap());
         EntityDto<EntityTotalDto> entityDto = new EntityDto<EntityTotalDto>("simpleName", entityTotalDto);

--- a/src/test/resources/config/document-tags/TEST.json
+++ b/src/test/resources/config/document-tags/TEST.json
@@ -1,0 +1,6 @@
+{
+  "type": "TEST",
+  "tags": [
+    "TEST_TAG"
+  ]
+}


### PR DESCRIPTION
Add the document tag information for all the case types on the system as configuration files.

Add a new document tag repository that replaces the existing `hocs-info-service` call to retrieve the document tags for a specific case type.