### PR TITLE
Json changes to add new document types to POGR and POGR2 cases

### DIFF
--- a/src/main/resources/config/document-tags/POGR.json
+++ b/src/main/resources/config/document-tags/POGR.json
@@ -4,6 +4,8 @@
     "Original Complaint",
     "Interim Letter",
     "Draft",
-    "Final Response"
+    "Final Response",
+    "Contribution Request",
+    "Contribution Response"
   ]
 }

--- a/src/main/resources/config/document-tags/POGR2.json
+++ b/src/main/resources/config/document-tags/POGR2.json
@@ -4,6 +4,8 @@
     "Original Complaint",
     "Interim Letter",
     "Draft",
-    "Final Response"
+    "Final Response",
+    "Contribution Request",
+    "Contribution Response"
   ]
 }


### PR DESCRIPTION
1. This bug was related to PR - https://github.com/UKHomeOffice/hocs-casework/pull/753/files where all hocs-data changes been migrated to hocs-casework. 
2. Previously my changes were part of hocs-data (PR- https://github.com/UKHomeOffice/hocs-data/pull/1295/files) were not migrated to hocs-casework PR hence this bug has been raised.
3. My fix to POGR and POGR2 json will add back Contribution Request and Contribution Response to document types for these 2 case types.
