### PR TITLE
HOCS-5691: add DRAFT document tag

### DIFF
--- a/src/main/resources/config/document-tags/IEDET.json
+++ b/src/main/resources/config/document-tags/IEDET.json
@@ -4,6 +4,7 @@
     "Original complaint",
     "Letter of Authority",
     "Interim response",
+    "DRAFT",
     "Final response",
     "Withdrawal letter",
     "Other"


### PR DESCRIPTION
Add the `DRAFT` document tag to the IEDET list.