### PR TITLE
HOCS-5711: Copy correspondents field value

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyBfToBf2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyBfToBf2.java
@@ -30,15 +30,15 @@ public class CopyBfToBf2 extends AbstractCaseCopyStrategy implements CaseCopyStr
 
     @Override
     public void copyCase(CaseData fromCase, CaseData toCase) {
+        // Correspondents include the primary_correspondent_uuid
+        correspondentService.copyCorrespondents(fromCase.getUuid(), toCase.getUuid());
 
         // copy clob details
         copyClobData(fromCase, toCase, DATA_CLOB_KEYS);
+        toCase.update("Correspondents", toCase.getPrimaryCorrespondentUUID().toString());
         toCase.update("PreviousCaseReference", fromCase.getReference());
         toCase.update("CompType", "Service");
         caseDataService.updateCaseData(toCase.getUuid(), null, toCase.getDataMap());
-
-        // Correspondents include the primary_correspondent_uuid
-        correspondentService.copyCorrespondents(fromCase.getUuid(), toCase.getUuid());
 
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
@@ -33,14 +33,13 @@ public class CopyCompToComp2 extends AbstractCaseCopyStrategy implements CaseCop
 
     @Override
     public void copyCase(CaseData fromCase, CaseData toCase) {
-
-        // copy clob details
-        copyClobData(fromCase, toCase, DATA_CLOB_KEYS);
-        caseDataService.updateCaseData(toCase.getUuid(), null, toCase.getDataMap());
-
         // Correspondents include the primary_correspondent_uuid
         correspondentService.copyCorrespondents(fromCase.getUuid(), toCase.getUuid());
 
+        // copy clob details
+        copyClobData(fromCase, toCase, DATA_CLOB_KEYS);
+        toCase.update("Correspondents", toCase.getPrimaryCorrespondentUUID().toString());
+        caseDataService.updateCaseData(toCase.getUuid(), null, toCase.getDataMap());
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRtoPOGR2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRtoPOGR2.java
@@ -7,6 +7,8 @@ import uk.gov.digital.ho.hocs.casework.api.CorrespondentService;
 import uk.gov.digital.ho.hocs.casework.api.factory.CaseCopy;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 
+import java.util.Map;
+
 @Service
 @CaseCopy(fromCaseType = "POGR", toCaseType = "POGR2")
 public class CopyPOGRtoPOGR2 extends AbstractCaseCopyStrategy implements CaseCopyStrategy {
@@ -30,10 +32,11 @@ public class CopyPOGRtoPOGR2 extends AbstractCaseCopyStrategy implements CaseCop
 
     @Override
     public void copyCase(CaseData fromCase, CaseData toCase) {
-        copyClobData(fromCase, toCase, DATA_CLOB_KEYS);
-        caseDataService.updateCaseData(toCase.getUuid(), null, toCase.getDataMap());
-
         correspondentService.copyCorrespondents(fromCase.getUuid(), toCase.getUuid());
+
+        copyClobData(fromCase, toCase, DATA_CLOB_KEYS);
+        toCase.update("Correspondents", toCase.getPrimaryCorrespondentUUID().toString());
+        caseDataService.updateCaseData(toCase.getUuid(), null, toCase.getDataMap());
     }
 
 }

--- a/src/main/resources/config/details/stages/POGR2.json
+++ b/src/main/resources/config/details/stages/POGR2.json
@@ -8,6 +8,21 @@
         "label": "When was the correspondence received?"
       },
       {
+        "component": "entity-list",
+        "props": {
+          "action": "CORRESPONDENT",
+          "entity": "correspondent",
+          "choices": "CASE_CORRESPONDENTS",
+          "addUrlPath": "addNoMp",
+          "hasAddLink": true,
+          "hasEditLink": true,
+          "hasRemoveLink": true,
+          "hideRemovePrimary": true
+        },
+        "name": "Correspondents",
+        "label": "Which is the primary correspondent?"
+      },
+      {
         "component": "radio",
         "props": {
           "choices": [

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyBfToBf2Test.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyBfToBf2Test.java
@@ -72,7 +72,7 @@ public class CopyBfToBf2Test {
 
     @Before
     public void setUp() {
-        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, null,
+        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, UUID.randomUUID(),
             null, null, null, null, false, null, null);
 
         FROM_CLOB.put("OwningCSU", "csu");

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2Test.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2Test.java
@@ -78,7 +78,7 @@ public class CopyCompToComp2Test {
 
     @Before
     public void setUp() {
-        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, null,
+        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, UUID.randomUUID(),
             null, null, null, null, false, null, null);
     }
 
@@ -97,7 +97,7 @@ public class CopyCompToComp2Test {
 
         // clob values were copied - there's a separate test for copying values
         assertThat(toCase.getDataMap()).isNotNull();
-        assertThat(toCase.getDataMap()).isEqualTo(FROM_CASE.getDataMap());
+        assertThat(toCase.getDataMap()).containsAllEntriesOf(FROM_CASE.getDataMap());
 
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRToPOGR2Test.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyPOGRToPOGR2Test.java
@@ -78,7 +78,7 @@ public class CopyPOGRToPOGR2Test {
 
     @Before
     public void setUp() {
-        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, null,
+        toCase = new CaseData(2L, TO_CASE_UUID, null, null, null, false, new HashMap<>(Map.of()), null, null, UUID.randomUUID(),
             null, null, null, null, false, null, null);
     }
 
@@ -96,7 +96,7 @@ public class CopyPOGRToPOGR2Test {
         verify(correspondentService, times(1)).copyCorrespondents(FROM_CASE.getUuid(), toCase.getUuid());
 
         assertThat(toCase.getDataMap()).isNotNull();
-        assertThat(toCase.getDataMap()).isEqualTo(FROM_CASE.getDataMap());
+        assertThat(toCase.getDataMap()).containsAllEntriesOf(FROM_CASE.getDataMap());
 
     }
 


### PR DESCRIPTION
This bug is happening because before the correspondents are confirmed during the workflow there is no value for the primary correspondent in the case data blob
