### PR TITLE
Lower log level for Case Details Groups

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataDetailsGroupsRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseDataDetailsGroupsRepository.java
@@ -30,7 +30,7 @@ public class CaseDataDetailsGroupsRepository extends JsonConfigFolderReader {
         var detailFields = detailsFields.get(type);
 
         if (detailFields == null) {
-            log.warn("No mapping found for type: {}", type, value(EVENT, CASE_DATA_DETAILS_NOT_FOUND));
+            log.info("No mapping found for type: {}", type, value(EVENT, CASE_DATA_DETAILS_NOT_FOUND));
             return Collections.emptyMap();
         }
         return detailFields;


### PR DESCRIPTION
One case type is currently within the case details groups, this is then causing log events at warn level as all other case types are in the stages configuration. As this is expected behaviour - this change lowers the log level to info from this repository.