### PR TITLE
Hocs 5583 - create correspondent for migrated case

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.hocs.casework.migration.api;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
@@ -75,6 +76,7 @@ public class MigrationCaseDataService {
             value(EVENT, MIGRATION_CASE_UPDATED));
     }
 
+    @Transactional
     CaseData createCompletedCase(String caseType, Map<String, String> data, LocalDate dateReceived) {
         log.debug("Creating Case of type: {}", caseType);
         Long caseNumber = caseDataRepository.getNextSeriesId();

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -19,6 +19,7 @@ import static uk.gov.digital.ho.hocs.casework.application.LogEvent.MIGRATION_CAS
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.MIGRATION_CASE_NOT_UPDATED_NULL_DATA;
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.MIGRATION_CASE_RETRIEVED;
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.MIGRATION_CASE_UPDATED;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.PRIMARY_CORRESPONDENT_UPDATED;
 
 @Service
 @Slf4j
@@ -82,6 +83,7 @@ public class MigrationCaseDataService {
         LocalDate deadline = LocalDate.now();
         caseData.setCaseDeadline(deadline);
         caseData.setCompleted(true);
+        //caseData.setPrimaryCorrespondentUUID( GET UUID of primary Correspondence );
         caseDataRepository.save(caseData);
         auditClient.createCaseAudit(caseData);
         return caseData;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -40,14 +40,18 @@ public class MigrationCaseDataService {
 
     protected final MigrationAuditClient migrationAuditClient;
 
+    protected final AuditClient auditClient;
+
     protected final InfoClient infoClient;
 
     public MigrationCaseDataService(CaseDataRepository caseDataRepository,
                                     InfoClient infoClient,
+                                    MigrationAuditClient migrationAuditClient,
                                     AuditClient auditClient,
                                     CorrespondentRepository correspondentRepository) {
         this.caseDataRepository = caseDataRepository;
         this.infoClient = infoClient;
+        this.migrationAuditClient = migrationAuditClient;
         this.auditClient = auditClient;
         this.correspondentRepository = correspondentRepository;
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -22,7 +22,7 @@ public class MigrationCaseResource {
     @PostMapping(value = "/migrate")
     public ResponseEntity<CreateCaseResponse> createMigrationCase(@RequestBody CreateMigrationCaseRequest request) {
         CaseData caseData = migrationCaseService.createMigrationCase(request.getType(), request.getStageType(),
-            request.getData(), request.getDateReceived(), request.getComplaintCorrespondents());
+            request.getData(), request.getDateReceived(), request.getPrimaryCorrespondent());
         return ResponseEntity.ok(CreateCaseResponse.from(caseData));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -22,7 +22,7 @@ public class MigrationCaseResource {
     @PostMapping(value = "/migrate")
     public ResponseEntity<CreateCaseResponse> createMigrationCase(@RequestBody CreateMigrationCaseRequest request) {
         CaseData caseData = migrationCaseService.createMigrationCase(request.getType(), request.getStageType(),
-            request.getData(), request.getDateReceived());
+            request.getData(), request.getDateReceived(), request.getComplaintCorrespondents());
         return ResponseEntity.ok(CreateCaseResponse.from(caseData));
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -3,16 +3,16 @@ package uk.gov.digital.ho.hocs.casework.migration.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import uk.gov.digital.ho.hocs.casework.api.CaseDataService;
 import uk.gov.digital.ho.hocs.casework.api.CorrespondentService;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
+import uk.gov.digital.ho.hocs.casework.domain.model.Address;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
-import uk.gov.digital.ho.hocs.casework.domain.repository.CaseDataRepository;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.ComplaintCorrespondent;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -55,33 +55,30 @@ public class MigrationCaseService {
     }
 
     CaseData createMigrationCase(String caseType, String stageType, Map<String, String> data, LocalDate dateReceived,
-                                 List<ComplaintCorrespondent> correspondents) {
+                                 MigrationComplaintCorrespondent primaryCorrespondent) {
         log.debug("Migrating Case of type: {}", caseType);
 
         CaseData caseData = migrationCaseDataService.createCompletedCase(caseType, data, dateReceived);
         Stage stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);
-        createCorrespondents(correspondents, caseData.getUuid(), stage.getUuid());
+        createPrimaryCorrespondent(primaryCorrespondent, caseData.getUuid(), stage.getUuid());
 
         return caseData;
     }
 
-    void createCorrespondents(List<ComplaintCorrespondent> correspondents, UUID caseUUID, UUID stageUUID) {
-        for (ComplaintCorrespondent correspondent : correspondents) {
-            createCorrespondent(correspondent, caseUUID, stageUUID);
-        }
-    }
-
-    void createCorrespondent(ComplaintCorrespondent correspondentDetails, UUID caseUUID, UUID stageUUID) {
-        log.debug("Creating Correspondent of Type: {} for Migrated Case: {}", correspondentDetails.getType(), caseUUID);
+    void createPrimaryCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID, UUID stageUUID) {
+        log.debug("Creating Correspondent of Type: {} for Migrated Case: {}", primaryCorrespondent.getCorrespondentType(), caseUUID);
         Correspondent correspondent = new Correspondent(caseUUID,
-            correspondentDetails.getType().toString(),
-            correspondentDetails.getFullname(),
-            null,
-            null,
-            correspondentDetails.getTelephone(),
-            correspondentDetails.getEmail(),
-            null,
-            null);
+            primaryCorrespondent.getCorrespondentType().toString(),
+            primaryCorrespondent.getFullName(),
+            primaryCorrespondent.getOrganisation(),
+            new Address(primaryCorrespondent.getPostcode(), primaryCorrespondent.getAddress1(),
+                primaryCorrespondent.getAddress2(), primaryCorrespondent.getAddress3(),
+                primaryCorrespondent.getCountry()
+            ),
+            primaryCorrespondent.getTelephone(),
+            primaryCorrespondent.getEmail(),
+            primaryCorrespondent.getReference(),
+            primaryCorrespondent.getReference());
 
         try {
             correspondentRepository.save(correspondent);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -4,8 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.ComplaintCorrespondent;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -22,11 +24,10 @@ public class MigrationCaseService {
         this.migrationStageService = migrationStageService;
     }
 
-    CaseData createMigrationCase(String caseType, String stageType, Map<String, String> data, LocalDate dateReceived) {
+    CaseData createMigrationCase(String caseType, String stageType, Map<String, String> data, LocalDate dateReceived, List<ComplaintCorrespondent> correspondents) {
         log.debug("Migrating Case of type: {}", caseType);
         CaseData caseData = migrationCaseDataService.createCompletedCase(caseType, data, dateReceived);
         Stage stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);
         return caseData;
     }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -1,29 +1,14 @@
 package uk.gov.digital.ho.hocs.casework.migration.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.casework.api.CorrespondentService;
-import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
-import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
-import uk.gov.digital.ho.hocs.casework.domain.model.Address;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
-import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
-import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.ComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
-import static net.logstash.logback.argument.StructuredArguments.value;
-import static uk.gov.digital.ho.hocs.casework.application.LogEvent.CORRESPONDENT_CREATED;
-import static uk.gov.digital.ho.hocs.casework.application.LogEvent.CORRESPONDENT_CREATE_FAILURE;
-import static uk.gov.digital.ho.hocs.casework.application.LogEvent.EVENT;
 
 @Service
 @Slf4j
@@ -35,23 +20,12 @@ public class MigrationCaseService {
 
     private final CorrespondentService correspondentService;
 
-    private final CorrespondentRepository correspondentRepository;
-
-
-    private final AuditClient auditClient;
-
-
-
     public MigrationCaseService(MigrationCaseDataService migrationCaseDataService,
                                 MigrationStageService migrationStageService,
-                                CorrespondentService correspondentService,
-                                CorrespondentRepository correspondentRepository,
-                                AuditClient auditClient) {
+                                CorrespondentService correspondentService) {
         this.migrationCaseDataService = migrationCaseDataService;
         this.migrationStageService = migrationStageService;
         this.correspondentService = correspondentService;
-        this.correspondentRepository = correspondentRepository;
-        this.auditClient = auditClient;
     }
 
     CaseData createMigrationCase(String caseType, String stageType, Map<String, String> data, LocalDate dateReceived,
@@ -60,44 +34,8 @@ public class MigrationCaseService {
 
         CaseData caseData = migrationCaseDataService.createCompletedCase(caseType, data, dateReceived);
         Stage stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);
-        createPrimaryCorrespondent(primaryCorrespondent, caseData.getUuid(), stage.getUuid());
+        migrationCaseDataService.createPrimaryCorrespondent(primaryCorrespondent, caseData.getUuid(), stage.getUuid());
 
         return caseData;
     }
-
-    void createPrimaryCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID, UUID stageUUID) {
-        log.debug("Creating Correspondent of Type: {} for Migrated Case: {}", primaryCorrespondent.getCorrespondentType(), caseUUID);
-        Correspondent correspondent = new Correspondent(caseUUID,
-            primaryCorrespondent.getCorrespondentType().toString(),
-            primaryCorrespondent.getFullName(),
-            primaryCorrespondent.getOrganisation(),
-            new Address(primaryCorrespondent.getPostcode(), primaryCorrespondent.getAddress1(),
-                primaryCorrespondent.getAddress2(), primaryCorrespondent.getAddress3(),
-                primaryCorrespondent.getCountry()
-            ),
-            primaryCorrespondent.getTelephone(),
-            primaryCorrespondent.getEmail(),
-            primaryCorrespondent.getReference(),
-            primaryCorrespondent.getReference());
-
-        try {
-            correspondentRepository.save(correspondent);
-            auditClient.createCorrespondentAudit(correspondent);
-
-            Set<Correspondent> caseCorrespondents = correspondentRepository.findAllByCaseUUID(caseUUID);
-
-            if (caseCorrespondents.size()==1) {
-                migrationCaseDataService.updatePrimaryCorrespondent(caseUUID,
-                    stageUUID,
-                    caseCorrespondents.stream().findFirst().get().getCaseUUID());
-            }
-
-        } catch(DataIntegrityViolationException e) {
-            throw new ApplicationExceptions.EntityCreationException(
-                String.format("Failed to create correspondent %s for Migrated Case: %s", correspondent.getUuid(), caseUUID),
-                CORRESPONDENT_CREATE_FAILURE, e);
-        }
-        log.info("Created Correspondent: {} for Migrated Case: {}", correspondent.getUuid(), caseUUID,
-            value(EVENT, CORRESPONDENT_CREATED));
-        }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationStageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationStageService.java
@@ -3,13 +3,9 @@ package uk.gov.digital.ho.hocs.casework.migration.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.digital.ho.hocs.casework.api.CaseworkConstants;
-import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
-import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.repository.StageRepository;
 
-import java.util.Map;
 import java.util.UUID;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
@@ -35,5 +31,4 @@ public class MigrationStageService {
             value(EVENT, STAGE_CREATED));
         return stage;
     }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/ComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/ComplaintCorrespondent.java
@@ -1,0 +1,36 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.lang.NonNull;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class ComplaintCorrespondent {
+
+    @NonNull
+    @JsonProperty(value = "type", required = true)
+    CorrespondentType type;
+
+    @NonNull
+    @NotEmpty
+    @JsonProperty(value = "fullname", required = true)
+    String fullname;
+
+    @JsonProperty("telephone")
+    String telephone;
+
+    @JsonProperty("email")
+    String email;
+
+    public ComplaintCorrespondent(@NonNull @NotEmpty @JsonProperty("fullname") String fullname, @NonNull @NotEmpty @JsonProperty("type") CorrespondentType type) {
+        this.fullname = fullname;
+        this.type = type;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/ComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/ComplaintCorrespondent.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.casework.migration.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -28,6 +29,7 @@ public class ComplaintCorrespondent {
     @JsonProperty("email")
     String email;
 
+    @JsonCreator
     public ComplaintCorrespondent(@NonNull @NotEmpty @JsonProperty("fullname") String fullname, @NonNull @NotEmpty @JsonProperty("type") CorrespondentType type) {
         this.fullname = fullname;
         this.type = type;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CorrespondentType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CorrespondentType.java
@@ -1,0 +1,6 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+public enum CorrespondentType {
+    COMPLAINANT,
+    THIRD_PARTY_REP,
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -3,11 +3,7 @@ package uk.gov.digital.ho.hocs.casework.migration.api.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseRequestInterface;
-
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -30,7 +26,6 @@ public class CreateMigrationCaseRequest {
     @JsonProperty("stageType")
     private String stageType;
 
-    @JsonProperty("complaintCorrespondents")
-    private List<ComplaintCorrespondent> complaintCorrespondents;
-
+    @JsonProperty("primaryCorrespondent")
+    private MigrationComplaintCorrespondent primaryCorrespondent;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -7,6 +7,7 @@ import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseRequestInterface;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,5 +29,8 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("stageType")
     private String stageType;
+
+    @JsonProperty("complaintCorrespondents")
+    private List<ComplaintCorrespondent> complaintCorrespondents;
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/MigrationComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/MigrationComplaintCorrespondent.java
@@ -1,0 +1,58 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.springframework.lang.NonNull;
+
+import javax.validation.constraints.NotEmpty;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class MigrationComplaintCorrespondent {
+
+    @NonNull
+    @NotEmpty
+    @JsonProperty(value = "fullName", required = true)
+    String fullName;
+
+    @NonNull
+    @NotEmpty
+    @JsonProperty(value = "correspondentType", required = true)
+    CorrespondentType correspondentType;
+
+    @JsonProperty("address1")
+    String address1;
+
+    @JsonProperty("address2")
+    String address2;
+
+    @JsonProperty("address3")
+    String address3;
+
+    @JsonProperty("postcode")
+    String postcode;
+
+    @JsonProperty("country")
+    String country;
+
+    @JsonProperty("organisation")
+    String organisation;
+
+    @JsonProperty("telephone")
+    String telephone;
+
+    @JsonProperty("email")
+    String email;
+
+    @JsonProperty("reference")
+    String reference;
+
+    public MigrationComplaintCorrespondent(@NonNull @NotEmpty  String fullName, @NonNull @NotEmpty CorrespondentType type) {
+        this.correspondentType = type;
+        this.fullName = fullName;
+    }
+}

--- a/src/main/resources/config/details/stages/IEDET.json
+++ b/src/main/resources/config/details/stages/IEDET.json
@@ -250,7 +250,7 @@
         "component": "entity-list",
         "props": {
           "entity": "document",
-          "choices": "CASE_DOCUMENT_LIST_FINAL_RESPONSE",
+          "choices": "CASE_DOCUMENT_LIST_IEDET_FINAL_RESPONSE",
           "hasAddLink": true,
           "hasRemoveLink": true
         },

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
+import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.Address;
@@ -53,9 +54,12 @@ public class MigrationCaseDataServiceTest {
     @Mock
     private MigrationAuditClient migrationAuditClient;
 
+    @Mock
+    private AuditClient auditClient;
+
     @Before
     public void setUp() {
-        this.migrationCaseDataService = new MigrationCaseDataService(caseDataRepository, infoClient, auditClient, correspondentRepository);
+        this.migrationCaseDataService = new MigrationCaseDataService(caseDataRepository, infoClient, migrationAuditClient, auditClient, correspondentRepository);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CaseDataRepository;
+import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -36,6 +37,9 @@ public class MigrationCaseDataServiceTest {
     private CaseDataRepository caseDataRepository;
 
     @Mock
+    private CorrespondentRepository correspondentRepository;
+
+    @Mock
     private InfoClient infoClient;
 
     @Mock
@@ -43,7 +47,7 @@ public class MigrationCaseDataServiceTest {
 
     @Before
     public void setUp() {
-        this.migrationCaseDataService = new MigrationCaseDataService(caseDataRepository, infoClient, auditClient);
+        this.migrationCaseDataService = new MigrationCaseDataService(caseDataRepository, infoClient, auditClient, correspondentRepository);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -102,15 +102,12 @@ public class MigrationCaseDataServiceTest {
     @Test
     public void shouldCreatedAPrimaryCorrespondent() {
         // given
-        UUID caseUUID = UUID.randomUUID();
-        when(infoClient.getCaseType(caseType.getDisplayCode())).thenReturn(caseType);
-        when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
+        CaseData caseData = new CaseData();
+        when(caseDataRepository.findActiveByUuid(any())).thenReturn(caseData);
 
         Set<Correspondent> correspondents = new HashSet<>();
         correspondents.add(createCorrespondent());
-        when(correspondentRepository.findAllByCaseUUID(caseUUID)).thenReturn(correspondents);
-
-        when(caseDataRepository.findActiveByUuid(caseUUID)).thenReturn(any());
+        when(correspondentRepository.findAllByCaseUUID(any())).thenReturn(correspondents);
 
         // when
         migrationCaseDataService.createPrimaryCorrespondent(createMigrationComplaintCorrespondent(), UUID.randomUUID(), UUID.randomUUID());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -49,14 +49,14 @@ public class MigrationCaseResourceTest {
         //given
         CaseData caseData = new CaseData(caseDataType, caseID, data, dateArg);
         CreateMigrationCaseRequest request = new CreateMigrationCaseRequest(caseDataType.getDisplayCode(), data,
-            dateArg, null, STAGE_TYPE);
+            dateArg, null, STAGE_TYPE, null);
         when(migrationCaseService.createMigrationCase(caseDataType.getDisplayCode(), STAGE_TYPE, data,
-            dateArg)).thenReturn(caseData);
+            dateArg, null)).thenReturn(caseData);
 
         ResponseEntity<CreateCaseResponse> response = migrationCaseResource.createMigrationCase(request);
 
         verify(migrationCaseService, times(1)).createMigrationCase(caseDataType.getDisplayCode(), STAGE_TYPE, data,
-            dateArg);
+            dateArg, null);
 
         verifyNoMoreInteractions(migrationCaseService);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -13,14 +13,13 @@ import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.ComplaintCorrespondent;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CorrespondentType;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -75,8 +74,8 @@ public class MigrationCaseServiceTest {
 
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
-        List<ComplaintCorrespondent> correspondents = new ArrayList<>();
-        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, correspondents);
+        MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
+        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, primaryCorrespondents);
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,
@@ -84,6 +83,22 @@ public class MigrationCaseServiceTest {
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);
+    }
+
+    MigrationComplaintCorrespondent createCorrespondent() {
+        return new MigrationComplaintCorrespondent(
+                "fullName",
+                CorrespondentType.COMPLAINANT,
+                "address1",
+                "address2",
+                "address3",
+                "postcode",
+                "country",
+                "organisation",
+                "telephone",
+                "email",
+                "reference"
+            );
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -83,6 +84,11 @@ public class MigrationCaseServiceTest {
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);
+    }
+
+    @Test
+    public void GivenAValidMigratedCaseWhenCaseIsCreatedThenShouldContainAPrimaryCorrespondent() {
+        fail();
     }
 
     MigrationComplaintCorrespondent createCorrespondent() {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -57,7 +57,7 @@ public class MigrationCaseServiceTest {
         when(migrationCaseDataService.createCompletedCase(caseDataType.getDisplayName(), data,
             originalReceivedDate)).thenReturn(caseData);
 
-        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate);
+        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, null);
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -5,20 +5,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.jdbc.core.simple.AbstractJdbcCall;
 import uk.gov.digital.ho.hocs.casework.api.CorrespondentService;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.ComplaintCorrespondent;
 
-import javax.sql.rowset.CachedRowSet;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -65,12 +67,16 @@ public class MigrationCaseServiceTest {
         Map<String, String> data = Collections.emptyMap();
         CaseData caseData = new CaseData(1L, UUID.randomUUID(), LocalDateTime.now(), "COMP", null, false, data, null,
             null, null, null, LocalDate.now(), LocalDate.now(), LocalDate.now().minusDays(10), false, null, null);
+        Stage stage = new Stage(caseData.getUuid(), STAGE_TYPE, null, null, null);
 
         //when
         when(migrationCaseDataService.createCompletedCase(caseDataType.getDisplayName(), data,
             originalReceivedDate)).thenReturn(caseData);
 
-        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, null);
+        when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
+
+        List<ComplaintCorrespondent> correspondents = new ArrayList<>();
+        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, correspondents);
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,


### PR DESCRIPTION
Create Primary Correspondent and set as the primary correspondent for a case.
Primary Correspondent is saved as a correspondent in the database, then set as the primary correspondent for the migrated case.