### PR TITLE
HOCS-5920: rework tagging functionality

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/StageWithCaseData.java
@@ -23,8 +23,10 @@ import javax.persistence.Transient;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static uk.gov.digital.ho.hocs.casework.application.LogEvent.STAGE_CREATE_FAILURE;
@@ -82,10 +84,9 @@ public class StageWithCaseData extends BaseStage {
     private String somu;
 
     @Getter
-    @OneToMany(fetch = FetchType.EAGER)
-    @JoinColumn(name = "case_uuid", referencedColumnName = "case_uuid")
-    @Where(clause = "deleted_on IS NULL")
-    private List<CaseDataTag> tag;
+    @Setter
+    @Transient
+    private Set<CaseDataTag> tag = new HashSet<>();
 
     @Getter
     @Setter
@@ -139,7 +140,7 @@ public class StageWithCaseData extends BaseStage {
         this.teamUUID = teamUUID;
         this.userUUID = userUUID;
         this.data = new HashMap<>();
-        this.tag = new ArrayList<>();
+        this.tag = new HashSet<>();
     }
 
     public StageWithCaseData() {
@@ -160,7 +161,7 @@ public class StageWithCaseData extends BaseStage {
 
     public void appendTags(List<String> tags) {
         if (tag == null) {
-            tag = new ArrayList<>();
+            tag = new HashSet<>();
         }
 
         tag.addAll(tags.stream().map(tagStr -> new CaseDataTag(this.caseUUID, tagStr)).toList());

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseTagRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/CaseTagRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseDataTag;
 
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
@@ -16,5 +17,7 @@ public interface CaseTagRepository extends org.springframework.data.repository.R
 
     @Modifying
     CaseDataTag save(CaseDataTag entity);
+
+    Set<CaseDataTag> findAllByCaseUuidIn(Set<UUID> caseUuids);
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseDataTag;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.repository.CaseTagRepository;
 import uk.gov.digital.ho.hocs.casework.domain.repository.StageRepository;
 import uk.gov.digital.ho.hocs.casework.priority.StagePriorityCalculator;
 import uk.gov.digital.ho.hocs.casework.security.SecurityExceptions;
@@ -130,6 +131,9 @@ public class StageServiceTest {
     @Mock
     private ActionDataDeadlineExtensionService extensionService;
 
+    @Mock
+    private CaseTagRepository caseTagRepository;
+
     private String ALLOCATION_TYPE = "ALLOCATION_TYPE";
 
     private final Set<Stage> MOCK_STAGE_LIST = new HashSet<>();
@@ -148,7 +152,8 @@ public class StageServiceTest {
 
         this.stageService = new StageService(stageRepository, userPermissionsService, notifyClient, auditClient,
             searchClient, infoClient, caseDataService, stagePriorityCalculator, daysElapsedCalculator,
-            stageTagsDecorator, caseNoteService, contributionsProcessor, extensionService, deadlineService);
+            stageTagsDecorator, caseNoteService, contributionsProcessor, extensionService, deadlineService,
+            caseTagRepository);
 
         MOCK_STAGE_LIST.clear();
         MOCK_STAGE_LIST.add(stageDraft);


### PR DESCRIPTION
There are currently performance issues with the tagging functionality whereby the use of native queries and JPA hibernate is causing queries per stage for tags.

While this functionality is being rewritten, this change falls back to using a 'somu'-esque loading mechanism to only query all stage tags at first.