### PR TITLE
HOCS-5946 Initial work to refactor workstacks to use JPA 

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
@@ -13,7 +13,12 @@ import java.util.Set;
 import java.util.UUID;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
-import static uk.gov.digital.ho.hocs.casework.application.LogEvent.*;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SOMU_ITEM_CREATED;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SOMU_ITEM_DELETED;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SOMU_ITEM_NOT_FOUND;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SOMU_ITEM_RETRIEVED;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SOMU_ITEM_UPDATED;
 
 @Service
 @Slf4j
@@ -29,18 +34,6 @@ public class SomuItemService {
     public SomuItemService(SomuItemRepository somuItemRepository, AuditClient auditClient) {
         this.somuItemRepository = somuItemRepository;
         this.auditClient = auditClient;
-    }
-
-    public Set<SomuItem> getCaseItemsByCaseUuids(Set<UUID> caseUuids) {
-        log.debug("Getting all Somu Items for Case: {}", caseUuids);
-
-        Set<SomuItem> somuItems = somuItemRepository.findAllByCaseUuidIn(caseUuids);
-        log.info("Got {} Somu Item for {} cases, Event {}", somuItems.size(), caseUuids.size(),
-            value(EVENT, SOMU_ITEM_RETRIEVED));
-
-        auditClient.viewAllSomuItemsForCasesAudit(caseUuids);
-
-        return somuItems;
     }
 
     public Set<SomuItem> getItemsByCaseUuid(UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -2,14 +2,12 @@ package uk.gov.digital.ho.hocs.casework.api;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageResponse;
@@ -20,7 +18,6 @@ import uk.gov.digital.ho.hocs.casework.api.dto.SearchRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageTeamRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.UpdateStageUserRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.WithdrawCaseRequest;
-import uk.gov.digital.ho.hocs.casework.application.RequestData;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.UserDto;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
@@ -87,16 +84,6 @@ class StageResource {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping(value = "/case/team/{teamUUID}/allocate/user/next")
-    ResponseEntity allocateStageUser(@PathVariable UUID teamUUID,
-                                     @RequestHeader(RequestData.USER_ID_HEADER) UUID userUUID) {
-        StageWithCaseData stage = stageService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID);
-        if (stage==null) {
-            return ResponseEntity.ok(stage);
-        }
-        return ResponseEntity.ok(GetStageResponse.from(stage));
-    }
-
     @GetMapping(value = "/case/{caseUUID}/stage/{stageUUID}/user")
     ResponseEntity<UUID> getStageUser(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID) {
         UUID userUUID = stageService.getStageUser(caseUUID, stageUUID);
@@ -135,24 +122,6 @@ class StageResource {
     ResponseEntity<String> getStageTypeFromStageData(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID) {
         String stageType = stageService.getStageType(caseUUID, stageUUID);
         return ResponseEntity.ok(stageType);
-    }
-
-    @GetMapping(value = "/stage/team/{teamUUID}")
-    ResponseEntity<GetStagesResponse> getActiveStagesByTeamUUID(@PathVariable UUID teamUUID) {
-        Set<StageWithCaseData> activeStages = stageService.getActiveStagesByTeamUUID(teamUUID);
-        return ResponseEntity.ok(GetStagesResponse.from(activeStages));
-    }
-
-    @GetMapping(value = "/stage")
-    ResponseEntity<GetStagesResponse> getActiveStages() {
-        Set<StageWithCaseData> activeStages = stageService.getActiveStagesForUsersTeams();
-        return ResponseEntity.ok(GetStagesResponse.from(activeStages));
-    }
-
-    @GetMapping(value = "/stage/user/{userUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<GetStagesResponse> getActiveStagesForUser(@PathVariable UUID userUuid) {
-        Set<StageWithCaseData> activeStages = stageService.getActiveUserStagesWithTeamsForUser(userUuid);
-        return ResponseEntity.ok(GetStagesResponse.from(activeStages));
     }
 
     @GetMapping(value = "/case/{reference:[a-zA-Z0-9]{2,}%2F[0-9]{7}%2F[0-9]{2}}/stage")

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResource.java
@@ -1,0 +1,58 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetWorkstackResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetWorkstacksResponse;
+import uk.gov.digital.ho.hocs.casework.application.RequestData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+class WorkstackResource {
+
+    private final WorkstackService workstackService;
+
+    public WorkstackResource(WorkstackService workstackService) {
+        this.workstackService = workstackService;
+    }
+
+    @GetMapping(value = "/stage/team/{teamUUID}")
+    ResponseEntity<GetWorkstacksResponse> getActiveStagesByTeamUUID(@PathVariable UUID teamUUID) {
+        Set<ActiveStage> activeStages = workstackService.getActiveStagesByTeamUUID(teamUUID);
+        return ResponseEntity.ok(GetWorkstacksResponse.from(activeStages));
+    }
+
+    @GetMapping(value = "/stage")
+    ResponseEntity<GetWorkstacksResponse> getActiveStages() {
+        Set<ActiveStage> activeStages = workstackService.getActiveStagesForUsersTeams();
+        return ResponseEntity.ok(GetWorkstacksResponse.from(activeStages));
+    }
+
+    @GetMapping(value = "/stage/user/{userUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<GetWorkstacksResponse> getActiveStagesForUser(@PathVariable UUID userUuid) {
+        Set<ActiveStage> activeStages = workstackService.getActiveUserStagesWithTeamsForUser(userUuid);
+        return ResponseEntity.ok(GetWorkstacksResponse.from(activeStages));
+    }
+
+    @PutMapping(value = "/case/team/{teamUUID}/allocate/user/next")
+    ResponseEntity allocateStageUser(@PathVariable UUID teamUUID,
+                                     @RequestHeader(RequestData.USER_ID_HEADER) UUID userUUID) {
+        ActiveStage stage = workstackService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID);
+        if (stage==null) {
+            return ResponseEntity.ok(stage);
+        }
+        return ResponseEntity.ok(GetWorkstackResponse.from(stage));
+    }
+
+}
+

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResource.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.casework.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -27,7 +28,7 @@ class WorkstackResource {
     }
 
     @GetMapping(value = "/stage/team/{teamUUID}")
-    ResponseEntity<GetWorkstacksResponse> getActiveStagesByTeamUUID(@PathVariable UUID teamUUID) {
+    public ResponseEntity<GetWorkstacksResponse> getActiveStagesByTeamUUID(@PathVariable UUID teamUUID) {
         Set<ActiveStage> activeStages = workstackService.getActiveStagesByTeamUUID(teamUUID);
         return ResponseEntity.ok(GetWorkstacksResponse.from(activeStages));
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
@@ -44,9 +44,6 @@ public class WorkstackService {
 
     private final StageService stageService;
 
-    @PersistenceContext
-    protected EntityManager entityManager;
-
     public WorkstackService(WorkstackStageRepository workstackRepository,
                             UserPermissionsService userPermissionsService,
                             StagePriorityCalculator stagePriorityCalculator,
@@ -172,10 +169,6 @@ public class WorkstackService {
     }
 
     private CaseData updateStages(CaseData caseData) {
-
-        if(entityManager != null) {
-            entityManager.detach(caseData);
-        }
 
         updateContribution(caseData);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
@@ -173,7 +173,10 @@ public class WorkstackService {
 
     private CaseData updateStages(CaseData caseData) {
 
-        entityManager.detach(caseData);
+        if(entityManager != null) {
+            entityManager.detach(caseData);
+        }
+
         updateContribution(caseData);
 
         stagePriorityCalculator.updatePriority(caseData, caseData.getType());

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/WorkstackService.java
@@ -1,0 +1,171 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.casework.contributions.ContributionsProcessor;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
+import uk.gov.digital.ho.hocs.casework.domain.repository.WorkstackStageRepository;
+import uk.gov.digital.ho.hocs.casework.priority.StagePriorityCalculator;
+import uk.gov.digital.ho.hocs.casework.security.SecurityExceptions;
+import uk.gov.digital.ho.hocs.casework.security.UserPermissionsService;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.SECURITY_FORBIDDEN;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.TEAMS_STAGE_LIST_EMPTY;
+import static uk.gov.digital.ho.hocs.casework.application.LogEvent.TEAMS_STAGE_LIST_RETRIEVED;
+
+@Slf4j
+@Service
+public class WorkstackService {
+
+    private final WorkstackStageRepository workstackRepository;
+
+    private final UserPermissionsService userPermissionsService;
+
+    private final StagePriorityCalculator stagePriorityCalculator;
+
+    private final DaysElapsedCalculator daysElapsedCalculator;
+
+    private final StageTagsDecorator stageTagsDecorator;
+
+    private final ContributionsProcessor contributionsProcessor;
+
+    private final StageService stageService;
+
+    public WorkstackService(WorkstackStageRepository workstackRepository,
+                            UserPermissionsService userPermissionsService,
+                            StagePriorityCalculator stagePriorityCalculator,
+                            DaysElapsedCalculator daysElapsedCalculator,
+                            StageTagsDecorator stageTagsDecorator,
+                            ContributionsProcessor contributionsProcessor,
+                            StageService stageService) {
+        this.stageService = stageService;
+        this.workstackRepository = workstackRepository;
+        this.userPermissionsService = userPermissionsService;
+        this.stagePriorityCalculator = stagePriorityCalculator;
+        this.daysElapsedCalculator = daysElapsedCalculator;
+        this.stageTagsDecorator = stageTagsDecorator;
+        this.contributionsProcessor = contributionsProcessor;
+    }
+
+    Set<ActiveStage> getActiveStagesByTeamUUID(UUID teamUUID) {
+        log.debug("Getting Active Stages for Team: {}", teamUUID);
+
+        Set<UUID> usersTeam = userPermissionsService.getExpandedUserTeams();
+
+        if (!usersTeam.contains(teamUUID)) {
+            log.warn("User {} attempted to view team {}", userPermissionsService.getUserId(), teamUUID,
+                value(EVENT, SECURITY_FORBIDDEN));
+            throw new SecurityExceptions.ForbiddenException("User does not have access to the requested resource",
+                SECURITY_FORBIDDEN);
+        }
+
+        Set<CaseData> cases = workstackRepository.findAllActiveByTeamUUID(teamUUID);
+
+        updateStages(cases);
+
+        return cases.stream().flatMap(caseData -> caseData.getActiveStages().stream()).collect(Collectors.toSet());
+    }
+
+    void updateContributions(Set<CaseData> cases) {
+        log.debug("Adding contributions data for stages");
+        contributionsProcessor.processContributionsForStages(cases);
+    }
+
+    ActiveStage getUnassignedAndActiveStageByTeamUUID(UUID teamUUID, UUID userUUID) {
+        log.debug("Getting unassigned cases for user: {} in team {}", userUUID, teamUUID);
+        Set<CaseData> unassignedCases = workstackRepository.findAllUnassignedAndActiveByTeamUUID(teamUUID);
+        if (unassignedCases.isEmpty()) {
+            log.debug("No unassigned case found for user: {} in team {}", userUUID, teamUUID);
+            return null;
+        }
+
+        for (CaseData caseData : unassignedCases) {
+            stagePriorityCalculator.updatePriority(caseData, caseData.getType());
+            daysElapsedCalculator.updateDaysElapsed(caseData.getDataMap(), caseData.getType());
+        }
+
+        double prevSystemCalculatedPriority = 0;
+        ActiveStage nextAvailableStage = unassignedCases.stream().findFirst().get().getActiveStages().stream().findFirst().get();
+        for (ActiveStage stage : unassignedCases.stream().flatMap(
+            caseData -> caseData.getActiveStages().stream()).toList()) {
+            double systemCalculatedPriority = 0.0;
+
+            try {
+                systemCalculatedPriority = Double.parseDouble(stage.getCaseData().getData("systemCalculatedPriority"));
+            } catch (NumberFormatException e) {
+                log.error("Error parsing systemCalculatedPriority for case: {}", stage.getCaseData().getUuid());
+            }
+
+            if (systemCalculatedPriority > prevSystemCalculatedPriority) {
+                prevSystemCalculatedPriority = systemCalculatedPriority;
+                nextAvailableStage = stage;
+            }
+        }
+
+        UUID caseUUID = nextAvailableStage.getCaseUUID();
+        UUID stageUUID = nextAvailableStage.getUuid();
+        stageService.updateStageUser(caseUUID, stageUUID, userUUID);
+
+        return nextAvailableStage;
+    }
+
+    Set<ActiveStage> getActiveStagesForUsersTeams() {
+        log.debug("Getting active stages for users teams");
+
+        Set<UUID> teams = userPermissionsService.getExpandedUserTeams();
+        if (teams.isEmpty()) {
+            log.warn("No teams - Returning 0 Stages", value(EVENT, TEAMS_STAGE_LIST_EMPTY));
+            return new HashSet<>(0);
+        }
+
+        Set<CaseData> cases = workstackRepository.findAllActiveByTeamUUID(teams);
+
+        updateStages(cases);
+
+        log.info("Returning {} Stages", cases.size(), value(EVENT, TEAMS_STAGE_LIST_RETRIEVED));
+        return cases.stream().flatMap(caseData -> caseData.getActiveStages().stream()).collect(Collectors.toSet());
+    }
+
+    Set<ActiveStage> getActiveUserStagesWithTeamsForUser(UUID userUuid) {
+        log.debug("Getting active stages for teams a user has and is also assigned to");
+
+        Set<UUID> teams = userPermissionsService.getExpandedUserTeams();
+        if (teams.isEmpty()) {
+            log.warn("No teams - Returning 0 Stages", value(EVENT, TEAMS_STAGE_LIST_EMPTY));
+            return new HashSet<>(0);
+        }
+
+        Set<CaseData> stages = workstackRepository.findAllActiveByUserUuidAndTeamUuid(userUuid, teams).stream().filter(
+            c -> !Optional.ofNullable(c.getData("Unworkable")).orElse("").equalsIgnoreCase("true")).collect(
+            Collectors.toSet());
+
+        updateStages(stages);
+
+        log.info("Returning {} Stages", stages.size(), value(EVENT, TEAMS_STAGE_LIST_RETRIEVED));
+        return stages.stream().flatMap(caseData -> caseData.getActiveStages().stream()).collect(Collectors.toSet());
+    }
+
+    private void updateStages(Set<CaseData> cases) {
+        updateContributions(cases);
+
+        for (CaseData caseData : cases) {
+            stagePriorityCalculator.updatePriority(caseData, caseData.getType());
+            daysElapsedCalculator.updateDaysElapsed(caseData.getDataMap(), caseData.getType());
+
+            //TODO: HOCS-5871 Remove after Workflow Implementation released
+            caseData.getActiveStages().forEach(stage -> {
+                caseData.appendTags(stageTagsDecorator.decorateTags(caseData.getDataMap(), stage.getStageType()));
+            });
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetWorkstackResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetWorkstackResponse.java
@@ -1,0 +1,114 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseDataTag;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetWorkstackResponse {
+
+    @JsonProperty("uuid")
+    private UUID uuid;
+
+    @JsonProperty("created")
+    private LocalDateTime created;
+
+    @JsonProperty("stageType")
+    private String stageType;
+
+    @JsonProperty("deadline")
+    private LocalDate deadline;
+
+    @JsonProperty("deadlineWarning")
+    private LocalDate deadlineWarning;
+
+    @JsonProperty("caseUUID")
+    private UUID caseUUID;
+
+    @JsonProperty("teamUUID")
+    private UUID teamUUID;
+
+    @JsonProperty("userUUID")
+    private UUID userUUID;
+
+    @JsonProperty("caseReference")
+    private String caseReference;
+
+    @JsonProperty("caseType")
+    private String caseDataType;
+
+    @JsonProperty("transitionNote")
+    private UUID transitionNoteUUID;
+
+    @JsonProperty("data")
+    private Map<String, String> data;
+
+    @JsonRawValue
+    private String somu;
+
+    @JsonProperty("correspondents")
+    private Set<WorkstackCorrespondentDto> correspondents;
+
+    @JsonProperty("caseCreated")
+    private LocalDateTime caseCreated;
+
+    @JsonProperty("active")
+    private boolean active;
+
+    @JsonProperty("assignedTopic")
+    private String assignedTopic;
+
+    @JsonProperty("tag")
+    private List<String> tag;
+
+    @JsonProperty("dueContribution")
+    private String dueContribution;
+
+    @JsonProperty("contributions")
+    private String contributions;
+
+    @JsonProperty
+    private String nextCaseType;
+
+    @JsonProperty
+    private String nextCaseReference;
+
+    @JsonProperty
+    private String nextCaseUUID;
+
+    @JsonProperty
+    private String nextCaseStageUUID;
+
+    public static GetWorkstackResponse from(ActiveStage stage) {
+        var tags = stage.getCaseData().getTag().stream().map(CaseDataTag::getTag).toList();
+
+        var correspondents = stage.getCaseData().getCorrespondents().stream().map(
+            correspondent -> WorkstackCorrespondentDto.from(correspondent,
+                stage.getCaseData().getPrimaryCorrespondentUUID())).collect(Collectors.toSet());
+
+        String topicText = null;
+        if (stage.getCaseData().getPrimaryTopic()!=null) {
+            topicText = stage.getCaseData().getPrimaryTopic().getText();
+        }
+
+        return new GetWorkstackResponse(stage.getUuid(), stage.getCreated(), stage.getStageType(), stage.getDeadline(),
+            stage.getDeadlineWarning(), stage.getCaseUUID(), stage.getTeamUUID(), stage.getUserUUID(),
+            stage.getCaseData().getReference(), stage.getCaseData().getType(), stage.getTransitionNoteUUID(),
+            stage.getCaseData().getDataMap(), null, correspondents, stage.getCaseData().getCreated(), true, topicText,
+            tags, stage.getDueContribution(), stage.getContributions(), stage.getNextCaseType(), null, null, null);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetWorkstacksResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/GetWorkstacksResponse.java
@@ -1,0 +1,26 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetWorkstacksResponse {
+
+    @JsonProperty("stages")
+    private Set<GetWorkstackResponse> stages;
+
+    public static GetWorkstacksResponse from(Set<ActiveStage> stages) {
+        Set<GetWorkstackResponse> stageDataResponses = stages.stream().map(GetWorkstackResponse::from).collect(
+            Collectors.toSet());
+
+        return new GetWorkstacksResponse(stageDataResponses);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/WorkstackCorrespondentDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/dto/WorkstackCorrespondentDto.java
@@ -1,0 +1,33 @@
+package uk.gov.digital.ho.hocs.casework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.Correspondent;
+
+import java.util.UUID;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class WorkstackCorrespondentDto {
+
+    @JsonProperty("fullname")
+    private String fullname;
+
+    @JsonProperty("postcode")
+    private String postcode;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("is_primary")
+    private boolean isPrivate;
+
+    public static WorkstackCorrespondentDto from(Correspondent correspondent, UUID primaryCorrespondentUUID) {
+        return new WorkstackCorrespondentDto(correspondent.getFullName(), correspondent.getPostcode(),
+            correspondent.getCorrespondentType(), correspondent.getUuid().equals(primaryCorrespondentUUID));
+
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
@@ -1,11 +1,11 @@
 package uk.gov.digital.ho.hocs.casework.contributions;
 
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 import java.util.Set;
 
 public interface ContributionsProcessor {
 
-    void processContributionsForStages(Set<StageWithCaseData> stage);
+    void processContributionsForStages(Set<CaseData> caseData);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessor.java
@@ -6,6 +6,6 @@ import java.util.Set;
 
 public interface ContributionsProcessor {
 
-    void processContributionsForStages(Set<CaseData> caseData);
+    void processContributionsForCase(CaseData caseData);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorImpl.java
@@ -36,11 +36,10 @@ public class ContributionsProcessorImpl implements ContributionsProcessor {
     }
 
     @Override
-    public void processContributionsForStages(Set<CaseData> cases) {
+    public void processContributionsForCase(CaseData caseData) {
 
-        for (ActiveStage stage : cases.stream().flatMap(caseData -> caseData.getActiveStages().stream()).collect(
-            Collectors.toSet())) {
-            if (infoClient.getStageContributions(stage.getStageType())) {
+        for (ActiveStage stage : caseData.getActiveStages().stream().collect(Collectors.toSet())) {
+            if (Boolean.TRUE.equals(infoClient.getStageContributions(stage.getStageType()))) {
                 Set<Contribution> contributions = stage.getCaseData().getSomu_items().stream().map(somuItem -> {
                     try {
                         return objectMapper.readValue(somuItem.getData(), Contribution.class);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/ActiveStage.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/ActiveStage.java
@@ -1,0 +1,102 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "WorkstackActiveStage")
+@Table(name = "active_stage")
+public class ActiveStage implements Serializable {
+
+    @Id
+    @Getter
+    @Column(name = "uuid", columnDefinition = "uuid")
+    private UUID uuid;
+
+    @Getter
+    @Column(name = "created")
+    private LocalDateTime created;
+
+    @Getter
+    @Column(name = "type")
+    private String stageType;
+
+    @Setter
+    @Getter
+    @Column(name = "deadline")
+    private LocalDate deadline;
+
+    @Setter
+    @Getter
+    @Column(name = "deadlineWarning")
+    private LocalDate deadlineWarning;
+
+    @Getter
+    @Column(name = "transition_note_uuid", columnDefinition = "uuid")
+    private UUID transitionNoteUUID;
+
+    @Getter
+    @Column(name = "case_uuid", columnDefinition = "uuid")
+    private UUID caseUUID;
+
+    @Getter
+    @Column(name = "team_uuid", columnDefinition = "uuid")
+    private UUID teamUUID;
+
+    @Getter
+    @Column(name = "user_uuid", columnDefinition = "uuid")
+    private UUID userUUID;
+
+    @Getter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    private CaseData caseData;
+
+    @Getter
+    @Setter
+    @Transient
+    private String dueContribution;
+
+    @Getter
+    @Setter
+    @Transient
+    private String contributions;
+
+    @Getter
+    @Setter
+    @Transient
+    @JsonInclude
+    private String nextCaseType;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        ActiveStage that = (ActiveStage) o;
+        return uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseData.java
@@ -1,0 +1,170 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@TypeDefs({ @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class) })
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "WorkstackCaseData")
+@Table(name = "case_data")
+public class CaseData implements Serializable {
+
+    @Id
+    @Getter
+    @Column(name = "uuid", columnDefinition = "uuid")
+    private UUID uuid;
+
+    @Getter
+    @Column(name = "created")
+    private LocalDateTime created = LocalDateTime.now();
+
+    @Getter
+    @Column(name = "type")
+    private String type;
+
+    @Getter
+    @Column(name = "reference")
+    private String reference;
+
+    @Setter
+    @Getter
+    @Column(name = "deleted")
+    private boolean deleted;
+
+    @Getter
+    @Setter(value = AccessLevel.PROTECTED)
+    @Type(type = "jsonb")
+    @Column(name = "data", columnDefinition = "jsonb")
+    private Map<String, String> dataMap = new HashMap<>(0);
+
+    @Setter
+    @Getter
+    @Column(name = "primary_topic_uuid")
+    private UUID primaryTopicUUID;
+
+    @Getter
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_topic_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    private Topic primaryTopic;
+
+    @Setter
+    @Getter
+    @Column(name = "primary_correspondent_uuid")
+    private UUID primaryCorrespondentUUID;
+
+    @Getter
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_correspondent_uuid",
+                referencedColumnName = "uuid",
+                insertable = false,
+                updatable = false)
+    private Correspondent primaryCorrespondent;
+
+    @Getter
+    @Setter
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_uuid", referencedColumnName = "uuid", insertable = false, updatable = false)
+    @Where(clause = "deleted = false")
+    private Set<Correspondent> correspondents;
+
+    @Setter
+    @Getter
+    @Column(name = "case_deadline")
+    private LocalDate caseDeadline;
+
+    @Setter
+    @Getter
+    @Column(name = "case_deadline_warning")
+    private LocalDate caseDeadlineWarning;
+
+    @Setter
+    @Getter
+    @Column(name = "date_received")
+    private LocalDate dateReceived;
+
+    @Setter
+    @Getter
+    @Column(name = "completed")
+    private boolean completed;
+
+    @Getter
+    @Setter
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_uuid", referencedColumnName = "uuid", insertable = false)
+    private Set<ActiveStage> activeStages;
+
+    @Getter
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_uuid", referencedColumnName = "uuid")
+    @Where(clause = "deleted_on IS NULL")
+    private Set<CaseDataTag> tag;
+
+    @Getter
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_uuid", referencedColumnName = "uuid")
+    private Set<SomuItem> somu_items;
+
+    public void update(Map<String, String> newData) {
+        if (newData!=null && newData.size() > 0) {
+            this.dataMap.putAll(newData);
+        }
+    }
+
+    public void update(String key, String value) {
+        this.dataMap.put(key, value);
+    }
+
+    public String getData(String key) {
+        return this.dataMap.getOrDefault(key, null);
+    }
+
+    public void appendTags(List<String> tags) {
+        if (tag==null) {
+            tag = new HashSet<>();
+        }
+        tag.addAll(tags.stream().map(tagStr -> new CaseDataTag(this.uuid, tagStr)).toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        CaseData caseData = (CaseData) o;
+        return uuid.equals(caseData.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseDataTag.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseDataTag.java
@@ -1,0 +1,71 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity(name = "WorkstackCaseDataTag")
+@Table(name = "case_data_tag")
+public class CaseDataTag implements Serializable {
+
+    @Id
+    @Column(name = "uuid")
+    private UUID uuid;
+
+    @Column(name = "case_uuid")
+    private UUID caseUuid;
+
+    @Column(name = "tag")
+    private String tag;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAtDate;
+
+    @Column(name = "deleted_on")
+    private LocalDateTime deletedOnDate;
+
+    public CaseDataTag(UUID caseUuid, String tag) {
+        this.uuid = UUID.randomUUID();
+        this.caseUuid = caseUuid;
+        this.tag = tag;
+    }
+
+    protected CaseDataTag() {}
+
+    public UUID getCaseUuid() {
+        return caseUuid;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public LocalDateTime getCreatedAtDate() {
+        return createdAtDate;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        createdAtDate = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        CaseDataTag that = (CaseDataTag) o;
+        return Objects.equals(caseUuid, that.caseUuid) && Objects.equals(tag, that.tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(caseUuid, tag);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseLink.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/CaseLink.java
@@ -1,0 +1,33 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.digital.ho.hocs.casework.domain.model.CaseLinkId;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Entity(name = "WorkstackCaseLink")
+@Table(name = "case_link")
+@IdClass(CaseLinkId.class)
+public class CaseLink {
+
+    @Getter
+    @Id
+    @Column(name = "primary_case_uuid")
+    private UUID primaryCase;
+
+    @Getter
+    @Id
+    @Column(name = "secondary_case_uuid")
+    private UUID secondaryCase;
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/Correspondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/Correspondent.java
@@ -1,0 +1,118 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "WorkstackCorrespondent")
+@Table(name = "correspondent")
+public class Correspondent implements Serializable {
+
+    @Id
+    @Getter
+    @Column(name = "uuid", columnDefinition = "uuid")
+    protected UUID uuid;
+
+    @Setter
+    @Getter
+    @Column(name = "created")
+    protected LocalDateTime created;
+
+    @Getter
+    @Column(name = "type")
+    protected String correspondentType;
+
+    @Getter
+    @Setter
+    @Transient
+    protected String correspondentTypeName;
+
+    @Getter
+    @Column(name = "case_uuid")
+    protected UUID caseUUID;
+
+    @Setter
+    @Getter
+    @Column(name = "fullname")
+    protected String fullName;
+
+    @Setter
+    @Getter
+    @Column(name = "organisation")
+    protected String organisation;
+
+    @Setter
+    @Getter
+    @Column(name = "postcode")
+    protected String postcode;
+
+    @Setter
+    @Getter
+    @Column(name = "address1")
+    protected String address1;
+
+    @Setter
+    @Getter
+    @Column(name = "address2")
+    protected String address2;
+
+    @Setter
+    @Getter
+    @Column(name = "address3")
+    protected String address3;
+
+    @Setter
+    @Getter
+    @Column(name = "country")
+    protected String country;
+
+    @Setter
+    @Getter
+    @Column(name = "telephone")
+    protected String telephone;
+
+    @Setter
+    @Getter
+    @Column(name = "email")
+    protected String email;
+
+    @Getter
+    @Column(name = "external_key")
+    protected String externalKey;
+
+    @Setter
+    @Getter
+    @Column(name = "reference")
+    protected String reference;
+
+    @Setter
+    @Getter
+    @Column(name = "deleted")
+    protected boolean deleted;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        Correspondent that = (Correspondent) o;
+        return uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/SomuItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/SomuItem.java
@@ -1,0 +1,59 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "WorkstackSomuItem")
+@Table(name = "somu_item")
+public class SomuItem implements Serializable {
+
+    @Id
+    @Getter
+    @Column(name = "uuid")
+    private UUID uuid;
+
+    @Getter
+    @Setter
+    @Column(name = "case_uuid")
+    private UUID caseUuid;
+
+    @Getter
+    @Setter
+    @Column(name = "somu_uuid")
+    private UUID somuUuid;
+
+    @Getter
+    @Setter
+    @Column(name = "data")
+    private String data;
+
+    public boolean isDeleted() {
+        return (data==null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        SomuItem somuItem = (SomuItem) o;
+        return uuid.equals(somuItem.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/Topic.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/workstacks/Topic.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.hocs.casework.domain.model.workstacks;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity(name = "WorkstackTopic")
+@Table(name = "topic")
+public class Topic implements Serializable {
+
+    @Id
+    @Column(name = "uuid")
+    @Getter
+    private UUID uuid;
+
+    @Column(name = "created")
+    @Getter
+    private LocalDateTime created;
+
+    @Column(name = "case_uuid")
+    @Getter
+    private UUID caseUUID;
+
+    @Column(name = "text")
+    @Getter
+    private String text;
+
+    @Column(name = "text_uuid")
+    @Getter
+    private UUID textUUID;
+
+    @Setter
+    @Getter
+    @Column(name = "deleted")
+    private boolean deleted;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this==o) {return true;}
+        if (o==null || getClass()!=o.getClass()) {return false;}
+        Topic topic = (Topic) o;
+        return uuid.equals(topic.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/StageRepository.java
@@ -53,10 +53,6 @@ public interface StageRepository extends CrudRepository<BaseStage, Long> {
            nativeQuery = true)
     Set<StageWithCaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
 
-    @Query(value = "SELECT * FROM stage_data sd WHERE user_uuid = ?1 AND NOT data @> CAST('{\"Unworkable\":\"True\"}' AS JSONB) AND sd.team_uuid IN ?2",
-           nativeQuery = true)
-    Set<StageWithCaseData> findAllActiveByUserUuidAndTeamUuid(UUID userUuid, Set<UUID> teamUUID);
-
     @Query(value = "SELECT sd.* FROM stage sd JOIN case_data cd ON sd.case_uuid = cd.uuid WHERE sd.user_uuid = ?1 AND sd.team_uuid = ?2 AND NOT cd.deleted",
            nativeQuery = true)
     Set<Stage> findStageCaseUUIDsByUserUUIDTeamUUID(UUID userUUID, UUID teamUUID);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
@@ -20,7 +20,7 @@ import static org.hibernate.jpa.QueryHints.HINT_READONLY;
 public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> {
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "2000"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
@@ -37,7 +37,7 @@ public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> 
     Set<CaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "2000"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.hocs.casework.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
+
+import javax.persistence.QueryHint;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH;
+import static org.hibernate.jpa.QueryHints.HINT_READONLY;
+
+@Repository
+public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> {
+
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 ORDER BY cd.uuid")
+    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
+        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+    Set<CaseData> findAllActiveByTeamUUID(UUID teamUUID);
+
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.userUUID = ?1 ORDER BY cd.uuid")
+    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
+        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+    Set<CaseData> findAllActiveByUserUUID(UUID userUUID);
+
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.userUUID = ?1 AND sd.teamUUID in ?2 ORDER BY cd.uuid")
+    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
+        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+    Set<CaseData> findAllActiveByUserUuidAndTeamUuid(UUID userUuid, Set<UUID> teamUUID);
+
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 AND sd.userUUID IS NULL ORDER BY cd.uuid")
+    Set<CaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
+
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
+    Set<CaseData> findAllActiveByTeamUUID(Set<UUID> teamUUID);
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
@@ -20,7 +20,7 @@ import static org.hibernate.jpa.QueryHints.HINT_READONLY;
 public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> {
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "2000"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
@@ -37,7 +37,7 @@ public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> 
     Set<CaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "100"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "2000"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
@@ -20,7 +20,7 @@ import static org.hibernate.jpa.QueryHints.HINT_READONLY;
 public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> {
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
@@ -37,7 +37,7 @@ public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> 
     Set<CaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"),
         @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/repository/WorkstackStageRepository.java
@@ -9,7 +9,10 @@ import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 import javax.persistence.QueryHint;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import static org.hibernate.jpa.QueryHints.HINT_CACHEABLE;
+import static org.hibernate.jpa.QueryHints.HINT_FETCH_SIZE;
 import static org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH;
 import static org.hibernate.jpa.QueryHints.HINT_READONLY;
 
@@ -17,24 +20,27 @@ import static org.hibernate.jpa.QueryHints.HINT_READONLY;
 public interface WorkstackStageRepository extends JpaRepository<CaseData, UUID> {
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
+        @QueryHint(name = HINT_CACHEABLE, value = "false"),
+        @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
-    Set<CaseData> findAllActiveByTeamUUID(UUID teamUUID);
-
-    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.userUUID = ?1 ORDER BY cd.uuid")
-    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
-        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
-    Set<CaseData> findAllActiveByUserUUID(UUID userUUID);
+    Stream<CaseData> findAllActiveByTeamUUID(UUID teamUUID);
 
     @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.userUUID = ?1 AND sd.teamUUID in ?2 ORDER BY cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
     Set<CaseData> findAllActiveByUserUuidAndTeamUuid(UUID userUuid, Set<UUID> teamUUID);
 
-    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 AND sd.userUUID IS NULL ORDER BY cd.uuid")
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID = ?1 AND sd.userUUID IS NULL ORDER BY cd.uuid")
+    @QueryHints(value = { @QueryHint(name = HINT_READONLY, value = "true"),
+        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
     Set<CaseData> findAllUnassignedAndActiveByTeamUUID(UUID teamUUID);
 
-    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
-    Set<CaseData> findAllActiveByTeamUUID(Set<UUID> teamUUID);
+    @Query(value = "SELECT distinct cd FROM WorkstackCaseData cd LEFT JOIN FETCH cd.activeStages sd LEFT JOIN FETCH cd.correspondents LEFT JOIN FETCH cd.primaryTopic LEFT JOIN FETCH cd.tag LEFT JOIN FETCH cd.somu_items WHERE sd.teamUUID in ?1 ORDER BY cd.uuid")
+    @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "100"),
+        @QueryHint(name = HINT_CACHEABLE, value = "false"),
+        @QueryHint(name = HINT_READONLY, value = "true"),
+        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+    Stream<CaseData> findAllActiveByTeamUUID(Set<UUID> teamUUID);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculator.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculator.java
@@ -1,11 +1,10 @@
 package uk.gov.digital.ho.hocs.casework.priority;
 
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
-
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 public interface StagePriorityCalculator {
 
     String SYSTEM_PRIORITY_FIELD_NAME = "systemCalculatedPriority";
 
-    void updatePriority(StageWithCaseData stage, String caseType);
+    void updatePriority(CaseData caseData, String caseType);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImpl.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/StagePriorityCalculatorImpl.java
@@ -2,12 +2,11 @@ package uk.gov.digital.ho.hocs.casework.priority;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 import uk.gov.digital.ho.hocs.casework.priority.policy.StagePriorityPolicy;
 
 @Service
 public class StagePriorityCalculatorImpl implements StagePriorityCalculator {
-
     private final StagePriorityPolicyProvider stagePriorityPolicyProvider;
 
     @Autowired
@@ -16,16 +15,17 @@ public class StagePriorityCalculatorImpl implements StagePriorityCalculator {
     }
 
     @Override
-    public void updatePriority(StageWithCaseData stageWithCaseData, String caseType) {
-        var caseData = stageWithCaseData.getData();
+    public void updatePriority(CaseData caseData, String caseType) {
+        var data = caseData.getDataMap();
 
-        double priority = 0;
-        for (StagePriorityPolicy policy : stagePriorityPolicyProvider.getPolicies(caseType)) {
-            priority += policy.apply(stageWithCaseData);
+        var policyProviders = stagePriorityPolicyProvider.getPolicies(caseType);
+
+        for (var stage : caseData.getActiveStages()) {
+            double priority = 0;
+            for (StagePriorityPolicy policy : policyProviders) {
+                priority += policy.apply(caseData, stage);
+            }
+            data.put(SYSTEM_PRIORITY_FIELD_NAME, String.valueOf(priority));
         }
-
-        caseData.put(SYSTEM_PRIORITY_FIELD_NAME, String.valueOf(priority));
-
     }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/DaysElapsedPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/DaysElapsedPolicy.java
@@ -3,12 +3,12 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 @AllArgsConstructor
 @Getter
@@ -29,8 +29,8 @@ public class DaysElapsedPolicy implements StagePriorityPolicy {
     private double pointsToAwardPerDay;
 
     @Override
-    public double apply(StageWithCaseData stageWithCaseData) {
-        var data = stageWithCaseData.getData();
+    public double apply(CaseData caseData, ActiveStage stage) {
+        var data = caseData.getDataMap();
 
         if (propertyValue.equals(data.get(propertyName))) {
             String dateString = data.get(dateFieldName);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/DeadlinePolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/DeadlinePolicy.java
@@ -1,16 +1,15 @@
 package uk.gov.digital.ho.hocs.casework.priority.policy;
 
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 import java.time.Duration;
 import java.time.LocalDate;
-
 public class DeadlinePolicy implements StagePriorityPolicy {
 
     @Override
-    public double apply(StageWithCaseData stageWithCaseData) {
-        var deadline = stageWithCaseData.getDeadline();
-
+    public double apply(CaseData caseData, ActiveStage stage) {
+        var deadline = stage.getDeadline();
         return Duration.between(deadline.atStartOfDay(), LocalDate.now().atStartOfDay()).toDays();
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/JoinedStringPropertyPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/JoinedStringPropertyPolicy.java
@@ -2,9 +2,8 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
-
-import java.util.Map;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 @AllArgsConstructor
 @Getter
@@ -21,8 +20,8 @@ public class JoinedStringPropertyPolicy implements StagePriorityPolicy {
     private double pointsToAward;
 
     @Override
-    public double apply(StageWithCaseData stageWithCaseData) {
-        var data = stageWithCaseData.getData();
+    public double apply(CaseData caseData, ActiveStage stage) {
+        var data = caseData.getDataMap();
 
         if (firstPropertyValue.equals(data.get(firstPropertyName)) && secondPropertyValue.equals(
             data.get(secondPropertyName))) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/SimpleStringPropertyPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/SimpleStringPropertyPolicy.java
@@ -2,10 +2,8 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
-
-import java.util.Map;
-
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 @AllArgsConstructor
 @Getter
 public class SimpleStringPropertyPolicy implements StagePriorityPolicy {
@@ -17,8 +15,8 @@ public class SimpleStringPropertyPolicy implements StagePriorityPolicy {
     private double pointsToAward;
 
     @Override
-    public double apply(StageWithCaseData stageWithCaseData) {
-        var data = stageWithCaseData.getData();
+    public double apply(CaseData caseData, ActiveStage stage) {
+        var data = caseData.getDataMap();
 
         if (propertyValue.equals(data.get(propertyName))) {
             return pointsToAward;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/StagePriorityPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/StagePriorityPolicy.java
@@ -1,9 +1,9 @@
 package uk.gov.digital.ho.hocs.casework.priority.policy;
 
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
-
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 public interface StagePriorityPolicy {
 
-    double apply(StageWithCaseData data);
+    double apply(CaseData caseData, ActiveStage stage);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicy.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/priority/policy/WorkingDaysElapsedPolicy.java
@@ -4,12 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
 import uk.gov.digital.ho.hocs.casework.api.WorkingDaysElapsedProvider;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
-
 @AllArgsConstructor
 @Getter
 public class WorkingDaysElapsedPolicy implements StagePriorityPolicy {
@@ -31,8 +30,8 @@ public class WorkingDaysElapsedPolicy implements StagePriorityPolicy {
     private double pointsToAwardPerDay;
 
     @Override
-    public double apply(StageWithCaseData stageWithCaseData) {
-        var data = stageWithCaseData.getData();
+    public double apply(CaseData caseData, ActiveStage stage) {
+        var data = caseData.getDataMap();
 
         if (propertyName!=null && propertyValue!=null && !propertyValue.equals(data.get(propertyName))) {
             return 0;
@@ -42,8 +41,7 @@ public class WorkingDaysElapsedPolicy implements StagePriorityPolicy {
         if (StringUtils.hasText(dateString)) {
             LocalDate dateToCheck = LocalDate.parse(dateString, DateTimeFormatter.ofPattern(dateFormat));
 
-            int daysElapsed = workingDaysElapsedProvider.getWorkingDaysSince(stageWithCaseData.getCaseDataType(),
-                dateToCheck);
+            int daysElapsed = workingDaysElapsedProvider.getWorkingDaysSince(caseData.getType(), dateToCheck);
             if (capNumberOfDays > -1 && daysElapsed >= capNumberOfDays) {
                 return capPointsToAward;
             }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageResourceTest.java
@@ -200,39 +200,6 @@ public class StageResourceTest {
     }
 
     @Test
-    public void testShouldGetActiveStages() {
-
-        Set<StageWithCaseData> stages = new HashSet<>();
-
-        when(stageService.getActiveStagesForUsersTeams()).thenReturn(stages);
-
-        ResponseEntity<GetStagesResponse> response = stageResource.getActiveStages();
-
-        verify(stageService).getActiveStagesForUsersTeams();
-
-        checkNoMoreInteractions();
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    }
-
-    @Test
-    public void testShouldGetActiveStagesForUser() {
-        Set<StageWithCaseData> stages = new HashSet<>();
-
-        when(stageService.getActiveUserStagesWithTeamsForUser(userUUID)).thenReturn(stages);
-
-        ResponseEntity<GetStagesResponse> response = stageResource.getActiveStagesForUser(userUUID);
-
-        verify(stageService).getActiveUserStagesWithTeamsForUser(userUUID);
-
-        checkNoMoreInteractions();
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    }
-
-    @Test
     public void testShouldGetActiveStagesCaseRef() throws UnsupportedEncodingException {
         String ref = "MIN/0123456/19";
 
@@ -372,28 +339,6 @@ public class StageResourceTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(users);
 
-    }
-
-    @Test
-    public void testAllocateStageUser() {
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID);
-        when(stageService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID)).thenReturn(stage);
-
-        ResponseEntity<GetStageResponse> response = stageResource.allocateStageUser(teamUUID, userUUID);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    }
-
-    @Test
-    public void testAllocateStageUser_withNoStage() {
-        StageWithCaseData stage = new StageWithCaseData(caseUUID, stageType, teamUUID, userUUID, transitionNoteUUID);
-        when(stageService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID)).thenReturn(null);
-
-        ResponseEntity<GetStageResponse> response = stageResource.allocateStageUser(teamUUID, userUUID);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     private void checkNoMoreInteractions() {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackResourceTest.java
@@ -1,0 +1,116 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetStageResponse;
+import uk.gov.digital.ho.hocs.casework.api.dto.GetWorkstacksResponse;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(WorkstackResource.class)
+@RunWith(SpringRunner.class)
+public class WorkstackResourceTest {
+
+    private final UUID caseUUID = UUID.randomUUID();
+
+    private final UUID teamUUID = UUID.randomUUID();
+
+    private final UUID userUUID = UUID.randomUUID();
+
+    private final UUID transitionNoteUUID = UUID.randomUUID();
+
+    private final String stageType = "DCU_MIN_MARKUP";
+
+    @MockBean
+    private WorkstackService workstackService;
+
+    private WorkstackResource workstackResource;
+
+    @Before
+    public void setUp() {
+        workstackResource = new WorkstackResource(workstackService);
+    }
+
+    @Test
+    public void testShouldGetActiveStages() {
+
+        Set<ActiveStage> stages = new HashSet<>();
+
+        when(workstackService.getActiveStagesForUsersTeams()).thenReturn(stages);
+
+        ResponseEntity<GetWorkstacksResponse> response = workstackResource.getActiveStages();
+
+        verify(workstackService).getActiveStagesForUsersTeams();
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testShouldGetActiveStagesForUser() {
+        Set<ActiveStage> stages = new HashSet<>();
+
+        when(workstackService.getActiveUserStagesWithTeamsForUser(userUUID)).thenReturn(stages);
+
+        ResponseEntity<GetWorkstacksResponse> response = workstackResource.getActiveStagesForUser(userUUID);
+
+        verify(workstackService).getActiveUserStagesWithTeamsForUser(userUUID);
+
+        checkNoMoreInteractions();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testAllocateStageUser() {
+        CaseData caseData = new CaseData(caseUUID, null, "COMP", "COMP/123456/22", false, Map.of(), null, null, null,
+            null, Collections.emptySet(), null, null, null, false, null, Collections.emptySet(), Set.of());
+
+        ActiveStage stage = new ActiveStage(caseUUID, LocalDateTime.now(), stageType, null, null, transitionNoteUUID,
+            caseUUID, teamUUID, userUUID, caseData, null, null, null);
+        when(workstackService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID)).thenReturn(stage);
+
+        ResponseEntity<GetStageResponse> response = workstackResource.allocateStageUser(teamUUID, userUUID);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void testAllocateStageUser_withNoStage() {
+
+        when(workstackService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID)).thenReturn(null);
+
+        ResponseEntity<GetStageResponse> response = workstackResource.allocateStageUser(teamUUID, userUUID);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private void checkNoMoreInteractions() {
+
+        verifyNoMoreInteractions(workstackService);
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackServiceTest.java
@@ -1,0 +1,299 @@
+package uk.gov.digital.ho.hocs.casework.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.casework.contributions.ContributionsProcessor;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseDataTag;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.SomuItem;
+import uk.gov.digital.ho.hocs.casework.domain.repository.WorkstackStageRepository;
+import uk.gov.digital.ho.hocs.casework.priority.StagePriorityCalculator;
+import uk.gov.digital.ho.hocs.casework.security.SecurityExceptions;
+import uk.gov.digital.ho.hocs.casework.security.UserPermissionsService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkstackServiceTest {
+
+    @Mock
+    private UserPermissionsService userPermissionsService;
+
+    @Mock
+    private WorkstackStageRepository workstackRepository;
+
+    @Mock
+    private StageService stageService;
+
+    @Mock
+    private ContributionsProcessor contributionsProcessor;
+
+    @Mock
+    private StagePriorityCalculator stagePriorityCalculator;
+
+    @Mock
+    private DaysElapsedCalculator daysElapsedCalculator;
+
+    @Mock
+    private StageTagsDecorator stageTagsDecorator;
+
+    private WorkstackService workstackService;
+
+    private final UUID transitionNoteUUID = UUID.randomUUID();
+
+    private final UUID caseUUID = UUID.randomUUID();
+
+    private final UUID teamUUID = UUID.randomUUID();
+
+    private final UUID userUUID = UUID.randomUUID();
+
+    private SomuItem somuItem;
+
+    private CaseData caseData;
+
+    private ActiveStage activeStage;
+
+    private LocalDateTime caseCreated = LocalDateTime.of(2022, 11, 1, 0, 0);
+
+    private LocalDate dateReveived = LocalDate.of(2022, 11, 1);
+
+    @Before
+    public void setUp() {
+        somuItem = new SomuItem(UUID.randomUUID(), caseUUID, UUID.randomUUID(),
+            "{ \"contributionDueDate\" : \"0000-12-31\"}");
+
+        caseData = new CaseData(caseUUID, caseCreated, "COMP", "COMP/123456/22", false, Map.of(), null, null, null,
+            null, Collections.emptySet(), null, null, dateReveived, false, null, Collections.emptySet(),
+            Set.of(somuItem));
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "COMP_SERVICE_TRIAGE", null, null,
+            transitionNoteUUID, caseUUID, teamUUID, userUUID, caseData, null, null, null);
+
+        caseData.setActiveStages(Set.of(activeStage));
+
+        workstackService = new WorkstackService(workstackRepository, userPermissionsService, stagePriorityCalculator,
+            daysElapsedCalculator, stageTagsDecorator, contributionsProcessor, stageService);
+
+    }
+
+    @Test
+    public void shouldGetActiveStages_blankResult() {
+        Set<UUID> teams = new HashSet<>();
+        teams.add(UUID.randomUUID());
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+
+        workstackService.getActiveStagesForUsersTeams();
+
+        verify(workstackRepository).findAllActiveByTeamUUID(teams);
+
+        verifyNoMoreInteractions(workstackRepository);
+    }
+
+    @Test
+    public void shouldGetActiveStages() {
+        Set<UUID> teams = new HashSet<>();
+        teams.add(UUID.randomUUID());
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+        when(workstackRepository.findAllActiveByTeamUUID(teams)).thenReturn(Set.of(caseData));
+
+        workstackService.getActiveStagesForUsersTeams();
+
+        verify(userPermissionsService).getExpandedUserTeams();
+        verify(workstackRepository).findAllActiveByTeamUUID(teams);
+        verify(stagePriorityCalculator).updatePriority(caseData, caseData.getType());
+        verify(daysElapsedCalculator).updateDaysElapsed(caseData.getDataMap(), caseData.getType());
+
+        checkNoMoreInteraction();
+    }
+
+    @Test
+    public void shouldGetActiveStagesEmpty() {
+        Set<UUID> teams = new HashSet<>();
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+
+        workstackService.getActiveStagesForUsersTeams();
+
+        // We don't try and get active stages with no teams (empty set) because we're going to get 0 results.
+        verify(userPermissionsService).getExpandedUserTeams();
+        checkNoMoreInteraction();
+
+    }
+
+    @Test
+    public void shouldGetUnassignedAndActiveStageByTeamUUID() {
+        workstackService.getUnassignedAndActiveStageByTeamUUID(teamUUID, userUUID);
+
+        verify(workstackRepository).findAllUnassignedAndActiveByTeamUUID(teamUUID);
+
+        verifyNoMoreInteractions(workstackRepository);
+    }
+
+    @Test
+    public void shouldGetActiveStagesByTeamUuids() {
+        Set<UUID> teamUuids = Set.of(teamUUID);
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teamUuids);
+        when(workstackRepository.findAllActiveByTeamUUID(teamUUID)).thenReturn(Set.of(caseData));
+
+        workstackService.getActiveStagesByTeamUUID(teamUUID);
+
+        verify(userPermissionsService).getExpandedUserTeams();
+        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(workstackRepository).findAllActiveByTeamUUID(teamUUID);
+    }
+
+    @Test(expected = SecurityExceptions.ForbiddenException.class)
+    public void shouldGetActiveStagesByTeamUuids_ForbiddenThrownWhenNotInTeam() {
+        Set<UUID> teamUuids = Set.of(UUID.randomUUID());
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teamUuids);
+
+        workstackService.getActiveStagesByTeamUUID(teamUUID);
+    }
+
+    @Test
+    public void shouldGetActiveUserStagesWithTeams() {
+        Set<UUID> teams = new HashSet<>();
+        teams.add(UUID.randomUUID());
+
+        caseData = new CaseData(caseUUID, caseCreated, "MIN", "MIN/123456/22", false, Map.of(), null, null, null, null,
+            Collections.emptySet(), null, null, dateReveived, false, null, Collections.emptySet(), Set.of(somuItem));
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null,
+            transitionNoteUUID, caseUUID, teamUUID, userUUID, caseData, null, null, null);
+        caseData.setActiveStages(Set.of(activeStage));
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+        when(workstackRepository.findAllActiveByUserUuidAndTeamUuid(userUUID, teams)).thenReturn(Set.of(caseData));
+
+        workstackService.getActiveUserStagesWithTeamsForUser(userUUID);
+
+        verify(userPermissionsService).getExpandedUserTeams();
+        verify(workstackRepository).findAllActiveByUserUuidAndTeamUuid(userUUID, teams);
+        verify(stagePriorityCalculator).updatePriority(caseData, caseData.getType());
+        verify(daysElapsedCalculator).updateDaysElapsed(caseData.getDataMap(), caseData.getType());
+
+        checkNoMoreInteraction();
+    }
+
+    @Test
+    public void shouldSetTagsOnStages() {
+        Set<UUID> teams = new HashSet<>();
+        teams.add(UUID.randomUUID());
+
+        caseData = new CaseData(caseUUID, caseCreated, "MIN", "MIN/123456/22", false, new HashMap<>(), null, null, null,
+            null, Collections.emptySet(), null, null, dateReveived, false, null, new HashSet<>(), Set.of());
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null,
+            transitionNoteUUID, caseUUID, teamUUID, userUUID, caseData, null, null, null);
+        caseData.setActiveStages(Set.of(activeStage));
+
+        ArrayList<String> tags = new ArrayList<>(Collections.singleton("HS"));
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+        when(workstackRepository.findAllActiveByUserUuidAndTeamUuid(userUUID, teams)).thenReturn(Set.of(caseData));
+        when(stageTagsDecorator.decorateTags(caseData.getDataMap(), activeStage.getStageType())).thenReturn(tags);
+
+        var result = workstackService.getActiveUserStagesWithTeamsForUser(userUUID);
+
+        verify(userPermissionsService).getExpandedUserTeams();
+        verify(workstackRepository).findAllActiveByUserUuidAndTeamUuid(userUUID, teams);
+        verify(stagePriorityCalculator).updatePriority(caseData, caseData.getType());
+        verify(daysElapsedCalculator).updateDaysElapsed(caseData.getDataMap(), caseData.getType());
+        verify(stageTagsDecorator).decorateTags(caseData.getDataMap(), activeStage.getStageType());
+
+        // assertThat(result).extracting(ActiveStage::getCaseData).extracting(CaseData::getTag).containsOnly(Set.of(new CaseDataTag(caseUUID, "HS")));
+
+        assertThat(result.iterator().next().getCaseData().getTag()).containsOnly(new CaseDataTag(caseUUID, "HS"));
+
+        checkNoMoreInteraction();
+    }
+
+    @Test
+    public void shouldGetActiveUserStagesWithTeamsAndCaseType_noTeams() {
+        Set<UUID> teams = new HashSet<>();
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+
+        workstackService.getActiveUserStagesWithTeamsForUser(userUUID);
+
+        verify(userPermissionsService).getExpandedUserTeams();
+        checkNoMoreInteraction();
+    }
+
+    @Test
+    public void getActiveUserStagesWithTeamsAndCaseType_blankResult() {
+        Set<UUID> teams = Set.of(UUID.randomUUID());
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+
+        workstackService.getActiveUserStagesWithTeamsForUser(userUUID);
+
+        verify(workstackRepository).findAllActiveByUserUuidAndTeamUuid(userUUID, teams);
+
+        verifyNoMoreInteractions(workstackRepository);
+    }
+
+    @Test
+    public void getActiveUserStagesWithTeamsAndCaseType_unworkableCases() {
+        Set<UUID> teams = Set.of(UUID.randomUUID());
+
+        var unworkableCaseUUID = UUID.randomUUID();
+        var workableCaseUUID = UUID.randomUUID();
+
+        var workableCaseData = new CaseData(workableCaseUUID, caseCreated, "MIN", "MIN/123456/22", false, Map.of(),
+            null, null, null, null, Collections.emptySet(), null, null, dateReveived, false, null,
+            Collections.emptySet(), Set.of());
+
+        var workableActiveStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null,
+            transitionNoteUUID, workableCaseUUID, teamUUID, userUUID, workableCaseData, null, null, null);
+        workableCaseData.setActiveStages(Set.of(workableActiveStage));
+
+        var unworkableCaseData = new CaseData(unworkableCaseUUID, caseCreated, "MIN", "MIN/123456/22", false,
+            Map.of("Unworkable", "true"), null, null, null, null, Collections.emptySet(), null, null, dateReveived,
+            false, null, Collections.emptySet(), Set.of());
+
+        var unworkableActiveStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null,
+            null, transitionNoteUUID, unworkableCaseUUID, teamUUID, userUUID, unworkableCaseData, null, null, null);
+        unworkableCaseData.setActiveStages(Set.of(unworkableActiveStage));
+
+        when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
+
+        when(workstackRepository.findAllActiveByUserUuidAndTeamUuid(userUUID, teams)).thenReturn(
+            Set.of(workableCaseData, unworkableCaseData));
+
+        var result = workstackService.getActiveUserStagesWithTeamsForUser(userUUID);
+
+        assertThat(result).extracting(ActiveStage::getCaseUUID).containsOnly(workableCaseUUID);
+
+        verify(workstackRepository).findAllActiveByUserUuidAndTeamUuid(userUUID, teams);
+
+        verifyNoMoreInteractions(workstackRepository);
+    }
+
+    private void checkNoMoreInteraction() {
+        verifyNoMoreInteractions(workstackRepository, userPermissionsService, stagePriorityCalculator,
+            daysElapsedCalculator);
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/WorkstackServiceTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -113,7 +114,7 @@ public class WorkstackServiceTest {
         teams.add(UUID.randomUUID());
 
         when(userPermissionsService.getExpandedUserTeams()).thenReturn(teams);
-        when(workstackRepository.findAllActiveByTeamUUID(teams)).thenReturn(Set.of(caseData));
+        when(workstackRepository.findAllActiveByTeamUUID(teams)).thenReturn(Stream.of(caseData));
 
         workstackService.getActiveStagesForUsersTeams();
 
@@ -153,12 +154,12 @@ public class WorkstackServiceTest {
         Set<UUID> teamUuids = Set.of(teamUUID);
 
         when(userPermissionsService.getExpandedUserTeams()).thenReturn(teamUuids);
-        when(workstackRepository.findAllActiveByTeamUUID(teamUUID)).thenReturn(Set.of(caseData));
+        when(workstackRepository.findAllActiveByTeamUUID(teamUUID)).thenReturn(Stream.of(caseData));
 
         workstackService.getActiveStagesByTeamUUID(teamUUID);
 
         verify(userPermissionsService).getExpandedUserTeams();
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verify(workstackRepository).findAllActiveByTeamUUID(teamUUID);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/contributions/ContributionsProcessorTest.java
@@ -68,24 +68,15 @@ public class ContributionsProcessorTest {
     }
 
     @Test
-    public void shouldReturnIfZeroSomuItems() {
-
-        contributionsProcessor.processContributionsForStages(Collections.emptySet());
-
-        verify(contributionsProcessor).processContributionsForStages(Collections.emptySet());
-        verifyNoMoreInteractions(contributionsProcessor);
-    }
-
-    @Test
     public void shouldNotReturnDataForNonContribution() {
         CaseData caseData = mock(CaseData.class);
 
         when(caseData.getType()).thenReturn("COMP");
         when(caseData.getSomu_items()).thenReturn(Collections.emptySet());
 
-        contributionsProcessor.processContributionsForStages(Set.of(caseData));
+        contributionsProcessor.processContributionsForCase(caseData);
 
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verifyNoMoreInteractions(contributionsProcessor);
     }
 
@@ -106,9 +97,9 @@ public class ContributionsProcessorTest {
 
         when(infoClient.getStageContributions(activeStage.getStageType())).thenReturn(true);
 
-        contributionsProcessor.processContributionsForStages(Set.of(caseData));
+        contributionsProcessor.processContributionsForCase(caseData);
 
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verify(contributionsProcessor).calculateDueContributionDate(any());
         verify(contributionsProcessor).highestContributionStatus(any());
         verify(contributionsProcessor).highestContributionStatus(any(), any());
@@ -136,9 +127,9 @@ public class ContributionsProcessorTest {
 
         when(infoClient.getStageContributions(activeStage.getStageType())).thenReturn(true);
 
-        contributionsProcessor.processContributionsForStages(Set.of(caseData));
+        contributionsProcessor.processContributionsForCase(caseData);
 
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verify(contributionsProcessor).calculateDueContributionDate(any());
         verify(contributionsProcessor).highestContributionStatus(any());
         verify(contributionsProcessor).highestContributionStatus(any(), any());
@@ -166,9 +157,9 @@ public class ContributionsProcessorTest {
 
         when(infoClient.getStageContributions(activeStage.getStageType())).thenReturn(true);
 
-        contributionsProcessor.processContributionsForStages(Set.of(caseData));
+        contributionsProcessor.processContributionsForCase(caseData);
 
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verify(contributionsProcessor).calculateDueContributionDate(any());
         verify(contributionsProcessor).highestContributionStatus(any());
         verify(contributionsProcessor).highestContributionStatus(any(), any());
@@ -196,9 +187,9 @@ public class ContributionsProcessorTest {
 
         when(infoClient.getStageContributions(activeStage.getStageType())).thenReturn(true);
 
-        contributionsProcessor.processContributionsForStages(Set.of(caseData));
+        contributionsProcessor.processContributionsForCase(caseData);
 
-        verify(contributionsProcessor).processContributionsForStages(Set.of(caseData));
+        verify(contributionsProcessor).processContributionsForCase(caseData);
         verify(contributionsProcessor).calculateDueContributionDate(any());
         verify(contributionsProcessor).highestContributionStatus(any());
         verify(contributionsProcessor).highestContributionStatus(any(), any());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/DeadlinePolicyTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/DeadlinePolicyTest.java
@@ -2,9 +2,15 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,38 +18,46 @@ public class DeadlinePolicyTest {
 
     private DeadlinePolicy policy;
 
-    private StageWithCaseData stage;
+    private CaseData caseData;
+
+    private ActiveStage activeStage;
 
     @Before
     public void before() {
-        stage = new StageWithCaseData();
+        var caseUUID = UUID.randomUUID();
+        caseData = new CaseData(caseUUID, LocalDateTime.now(), "MIN", "MIN/123456/22", false, Map.of(), null, null,
+            null, null, Collections.emptySet(), null, null, LocalDate.now(), false, null, Collections.emptySet(),
+            Set.of());
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null, null,
+            caseUUID, null, null, caseData, null, null, null);
+        caseData.setActiveStages(Set.of(activeStage));
         policy = new DeadlinePolicy();
-        ;
     }
 
     @Test
     public void apply_withDateNow() {
-        stage.setDeadline(LocalDate.now());
+        activeStage.setDeadline(LocalDate.now());
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
 
         assertThat(result).isZero();
     }
 
     @Test
     public void apply_withDateInFuture() {
-        stage.setDeadline(LocalDate.now().plusDays(1));
+        activeStage.setDeadline(LocalDate.now().plusDays(1));
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
 
         assertThat(result).isEqualTo(-1);
     }
 
     @Test
     public void apply_withDateInPast() {
-        stage.setDeadline(LocalDate.now().minusDays(1));
+        activeStage.setDeadline(LocalDate.now().minusDays(1));
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
 
         assertThat(result).isEqualTo(1);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/JoinedStringPropertyPolicyTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/JoinedStringPropertyPolicyTest.java
@@ -2,9 +2,15 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
-import java.util.Map;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,7 +18,9 @@ public class JoinedStringPropertyPolicyTest {
 
     private JoinedStringPropertyPolicy policy;
 
-    private StageWithCaseData stage;
+    private CaseData caseData;
+
+    private ActiveStage activeStage;
 
     private static final String PROPERTY_NAME_1 = "property1";
 
@@ -26,33 +34,40 @@ public class JoinedStringPropertyPolicyTest {
 
     @Before
     public void before() {
-        stage = new StageWithCaseData();
+        var caseUUID = UUID.randomUUID();
+        caseData = new CaseData(caseUUID, LocalDateTime.now(), "MIN", "MIN/123456/22", false, new HashMap<>(), null,
+            null, null, null, Collections.emptySet(), null, null, LocalDate.now(), false, null, Collections.emptySet(),
+            Set.of());
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null, null,
+            caseUUID, null, null, caseData, null, null, null);
+        caseData.setActiveStages(Set.of(activeStage));
         policy = new JoinedStringPropertyPolicy(PROPERTY_NAME_1, PROPERTY_VALUE_1, PROPERTY_NAME_2, PROPERTY_VALUE_2,
             POINTS_TO_AWARD);
     }
 
     @Test
     public void apply_criteriaMatched() {
-        stage.putData(PROPERTY_NAME_1, PROPERTY_VALUE_1);
-        stage.putData(PROPERTY_NAME_2, PROPERTY_VALUE_2);
+        caseData.update(PROPERTY_NAME_1, PROPERTY_VALUE_1);
+        caseData.update(PROPERTY_NAME_2, PROPERTY_VALUE_2);
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
         assertThat(result).isEqualTo(POINTS_TO_AWARD);
     }
 
     @Test
     public void apply_criteriaNotMatched() {
-        stage.putData(PROPERTY_NAME_1, "1");
-        stage.putData(PROPERTY_NAME_2, "2");
+        caseData.update(PROPERTY_NAME_1, "1");
+        caseData.update(PROPERTY_NAME_2, "2");
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
 
         assertThat(result).isZero();
     }
 
     @Test
     public void apply_propertyMissing() {
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
         assertThat(result).isZero();
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/SimpleStringPropertyPolicyTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/priority/policy/SimpleStringPropertyPolicyTest.java
@@ -2,9 +2,15 @@ package uk.gov.digital.ho.hocs.casework.priority.policy;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.digital.ho.hocs.casework.domain.model.StageWithCaseData;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.ActiveStage;
+import uk.gov.digital.ho.hocs.casework.domain.model.workstacks.CaseData;
 
-import java.util.Map;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,7 +18,9 @@ public class SimpleStringPropertyPolicyTest {
 
     private SimpleStringPropertyPolicy policy;
 
-    private StageWithCaseData stage;
+    private CaseData caseData;
+
+    private ActiveStage activeStage;
 
     private static final String PROPERTY_NAME = "property1";
 
@@ -22,29 +30,36 @@ public class SimpleStringPropertyPolicyTest {
 
     @Before
     public void before() {
-        stage = new StageWithCaseData();
+        var caseUUID = UUID.randomUUID();
+        caseData = new CaseData(caseUUID, LocalDateTime.now(), "MIN", "MIN/123456/22", false, new HashMap<>(), null,
+            null, null, null, Collections.emptySet(), null, null, LocalDate.now(), false, null, Collections.emptySet(),
+            Set.of());
+
+        activeStage = new ActiveStage(UUID.randomUUID(), LocalDateTime.now(), "DCU_MIN_MARKUP", null, null, null,
+            caseUUID, null, null, caseData, null, null, null);
+        caseData.setActiveStages(Set.of(activeStage));
         policy = new SimpleStringPropertyPolicy(PROPERTY_NAME, PROPERTY_VALUE, POINTS_TO_AWARD);
     }
 
     @Test
     public void apply_criteriaMatched() {
-        stage.putData(PROPERTY_NAME, PROPERTY_VALUE);
+        caseData.update(PROPERTY_NAME, PROPERTY_VALUE);
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
         assertThat(result).isEqualTo(POINTS_TO_AWARD);
     }
 
     @Test
     public void apply_criteriaNotMatched() {
-        stage.putData(PROPERTY_NAME, "C");
+        caseData.update(PROPERTY_NAME, "C");
 
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
         assertThat(result).isZero();
     }
 
     @Test
     public void apply_propertyMissing() {
-        double result = policy.apply(stage);
+        double result = policy.apply(caseData, activeStage);
         assertThat(result).isZero();
     }
 


### PR DESCRIPTION
HOCS-5946 Initial work to refactor workstacks to use JPA read only queries to improve performance and move away from the StageWithCaseData view.

- Move Workstack specific code to new services and resources
- Use JPA Fetch queries instead of calling StageWithData View
- Use Workstack specific entities to enable using Fetch queries which require the @ID to be on the key used in foreign constraints
- Use CaseData as the root class rather than Stage - refactor of Contributions and Policies

Outstanding work:
- Case Link entity needs adding to CaseData
- Review test coverage to ensure we have adequate testing in place for workstacks
- performance smoke test to ensure it performs as expected in a prod like environment
- further refactoring, particularly of tests to make the code cleaner
