### PR TITLE
HOCS-5714 Create additional correspondents for migrated case

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -110,18 +110,7 @@ public class MigrationCaseDataService {
 
     void createPrimaryCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID, UUID stageUUID) {
         log.debug("Creating Correspondent of Type: {} for Migrated Case: {}", primaryCorrespondent.getCorrespondentType(), caseUUID);
-        Correspondent correspondent = new Correspondent(caseUUID,
-            primaryCorrespondent.getCorrespondentType().toString(),
-            primaryCorrespondent.getFullName(),
-            primaryCorrespondent.getOrganisation(),
-            new Address(primaryCorrespondent.getPostcode(),
-                primaryCorrespondent.getAddress1(), primaryCorrespondent.getAddress2(), primaryCorrespondent.getAddress3(),
-                primaryCorrespondent.getCountry()
-            ),
-            primaryCorrespondent.getTelephone(),
-            primaryCorrespondent.getEmail(),
-            primaryCorrespondent.getReference(),
-            primaryCorrespondent.getReference());
+        Correspondent correspondent = getCorrespondent(primaryCorrespondent, caseUUID);
 
         try {
             correspondentRepository.save(correspondent);
@@ -157,18 +146,7 @@ public class MigrationCaseDataService {
     void createAdditionalCorrespondent(List<MigrationComplaintCorrespondent> additionalCorrespondents, UUID caseUUID, UUID stageUUID) {
         for (MigrationComplaintCorrespondent additionalCorrespondent : additionalCorrespondents) {
             log.debug("Creating Additional Correspondent of Type: {} for Migrated Case: {}", additionalCorrespondent.getCorrespondentType(), caseUUID);
-            Correspondent correspondent = new Correspondent(caseUUID,
-                additionalCorrespondent.getCorrespondentType().toString(),
-                additionalCorrespondent.getFullName(),
-                additionalCorrespondent.getOrganisation(),
-                new Address(additionalCorrespondent.getPostcode(),
-                    additionalCorrespondent.getAddress1(), additionalCorrespondent.getAddress2(), additionalCorrespondent.getAddress3(),
-                    additionalCorrespondent.getCountry()
-                ),
-                additionalCorrespondent.getTelephone(),
-                additionalCorrespondent.getEmail(),
-                additionalCorrespondent.getReference(),
-                additionalCorrespondent.getReference());
+            Correspondent correspondent = getCorrespondent(additionalCorrespondent, caseUUID);
 
             try {
                 correspondentRepository.save(correspondent);
@@ -182,5 +160,21 @@ public class MigrationCaseDataService {
             log.info("Created Correspondent: {} for Migrated Case: {}", correspondent.getUuid(), caseUUID,
                 value(EVENT, CORRESPONDENT_CREATED));
         }
+    }
+
+    private Correspondent getCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID) {
+        Correspondent correspondent = new Correspondent(caseUUID,
+            primaryCorrespondent.getCorrespondentType().toString(),
+            primaryCorrespondent.getFullName(),
+            primaryCorrespondent.getOrganisation(),
+            new Address(primaryCorrespondent.getPostcode(),
+                primaryCorrespondent.getAddress1(), primaryCorrespondent.getAddress2(), primaryCorrespondent.getAddress3(),
+                primaryCorrespondent.getCountry()
+            ),
+            primaryCorrespondent.getTelephone(),
+            primaryCorrespondent.getEmail(),
+            primaryCorrespondent.getReference(),
+            primaryCorrespondent.getReference());
+        return correspondent;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -162,19 +162,19 @@ public class MigrationCaseDataService {
         }
     }
 
-    private Correspondent getCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID) {
+    private Correspondent getCorrespondent(MigrationComplaintCorrespondent complaintCorrespondent, UUID caseUUID) {
         Correspondent correspondent = new Correspondent(caseUUID,
-            primaryCorrespondent.getCorrespondentType().toString(),
-            primaryCorrespondent.getFullName(),
-            primaryCorrespondent.getOrganisation(),
-            new Address(primaryCorrespondent.getPostcode(),
-                primaryCorrespondent.getAddress1(), primaryCorrespondent.getAddress2(), primaryCorrespondent.getAddress3(),
-                primaryCorrespondent.getCountry()
+            complaintCorrespondent.getCorrespondentType().toString(),
+            complaintCorrespondent.getFullName(),
+            complaintCorrespondent.getOrganisation(),
+            new Address(complaintCorrespondent.getPostcode(),
+                complaintCorrespondent.getAddress1(), complaintCorrespondent.getAddress2(), complaintCorrespondent.getAddress3(),
+                complaintCorrespondent.getCountry()
             ),
-            primaryCorrespondent.getTelephone(),
-            primaryCorrespondent.getEmail(),
-            primaryCorrespondent.getReference(),
-            primaryCorrespondent.getReference());
+            complaintCorrespondent.getTelephone(),
+            complaintCorrespondent.getEmail(),
+            complaintCorrespondent.getReference(),
+            complaintCorrespondent.getReference());
         return correspondent;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -21,9 +21,13 @@ public class MigrationCaseResource {
 
     @PostMapping(value = "/migrate")
     public ResponseEntity<CreateCaseResponse> createMigrationCase(@RequestBody CreateMigrationCaseRequest request) {
-        CaseData caseData = migrationCaseService.createMigrationCase(request.getType(), request.getStageType(),
-            request.getData(), request.getDateReceived(), request.getPrimaryCorrespondent());
+        CaseData caseData = migrationCaseService.createMigrationCase(
+            request.getType(),
+            request.getStageType(),
+            request.getData(),
+            request.getDateReceived(),
+            request.getPrimaryCorrespondent(),
+            request.getAdditionalCorrespondents());
         return ResponseEntity.ok(CreateCaseResponse.from(caseData));
     }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -8,6 +8,7 @@ import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -29,13 +30,13 @@ public class MigrationCaseService {
     }
 
     CaseData createMigrationCase(String caseType, String stageType, Map<String, String> data, LocalDate dateReceived,
-                                 MigrationComplaintCorrespondent primaryCorrespondent) {
+                                 MigrationComplaintCorrespondent primaryCorrespondent, List<MigrationComplaintCorrespondent> additionalCorrespondents) {
         log.debug("Migrating Case of type: {}", caseType);
 
         CaseData caseData = migrationCaseDataService.createCompletedCase(caseType, data, dateReceived);
         Stage stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);
         migrationCaseDataService.createPrimaryCorrespondent(primaryCorrespondent, caseData.getUuid(), stage.getUuid());
-
+        migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
         return caseData;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,4 +29,7 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("primaryCorrespondent")
     private MigrationComplaintCorrespondent primaryCorrespondent;
+
+    @JsonProperty("additionalCorrespondents")
+    private List<MigrationComplaintCorrespondent> additionalCorrespondents;
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -20,9 +20,10 @@ import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorre
 import uk.gov.digital.ho.hocs.casework.migration.client.auditclient.MigrationAuditClient;
 
 import java.time.LocalDate;
-import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -118,6 +119,24 @@ public class MigrationCaseDataServiceTest {
         //then
         verify(correspondentRepository, times(1)).save(any());
         verify(caseDataRepository, times(1)).save(any());
+    }
+
+    @Test
+    public void shouldCreatedAnAdditionalCorrespondent() {
+        // given
+        Set<Correspondent> correspondents = new HashSet<>();
+        correspondents.add(createCorrespondent());
+        when(correspondentRepository.findAllByCaseUUID(any())).thenReturn(correspondents);
+
+        List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
+        additionalCorrespondents.add(createMigrationComplaintCorrespondent());
+
+        // when
+        migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, UUID.randomUUID(), UUID.randomUUID());
+
+        //then
+        verify(correspondentRepository, times(1)).save(any());
+        //verify(caseDataRepository, times(1)).save(any());
     }
 
     MigrationComplaintCorrespondent createMigrationComplaintCorrespondent() {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -122,7 +122,7 @@ public class MigrationCaseDataServiceTest {
     }
 
     @Test
-    public void shouldCreatedAnAdditionalCorrespondent() {
+    public void shouldCreateAnAdditionalCorrespondent() {
         // given
         Set<Correspondent> correspondents = new HashSet<>();
         correspondents.add(createCorrespondent());
@@ -136,7 +136,6 @@ public class MigrationCaseDataServiceTest {
 
         //then
         verify(correspondentRepository, times(1)).save(any());
-        //verify(caseDataRepository, times(1)).save(any());
     }
 
     MigrationComplaintCorrespondent createMigrationComplaintCorrespondent() {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -126,7 +126,6 @@ public class MigrationCaseDataServiceTest {
         // given
         Set<Correspondent> correspondents = new HashSet<>();
         correspondents.add(createCorrespondent());
-        when(correspondentRepository.findAllByCaseUUID(any())).thenReturn(correspondents);
 
         List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
         additionalCorrespondents.add(createMigrationComplaintCorrespondent());

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -49,14 +49,14 @@ public class MigrationCaseResourceTest {
         //given
         CaseData caseData = new CaseData(caseDataType, caseID, data, dateArg);
         CreateMigrationCaseRequest request = new CreateMigrationCaseRequest(caseDataType.getDisplayCode(), data,
-            dateArg, null, STAGE_TYPE, null);
+            dateArg, null, STAGE_TYPE, null, null);
         when(migrationCaseService.createMigrationCase(caseDataType.getDisplayCode(), STAGE_TYPE, data,
-            dateArg, null)).thenReturn(caseData);
+            dateArg, null, null)).thenReturn(caseData);
 
         ResponseEntity<CreateCaseResponse> response = migrationCaseResource.createMigrationCase(request);
 
         verify(migrationCaseService, times(1)).createMigrationCase(caseDataType.getDisplayCode(), STAGE_TYPE, data,
-            dateArg, null);
+            dateArg, null, null);
 
         verifyNoMoreInteractions(migrationCaseService);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
-import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CorrespondentType;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
@@ -23,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -75,7 +73,7 @@ public class MigrationCaseServiceTest {
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
         MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
-        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, primaryCorrespondents);
+        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, primaryCorrespondents, Collections.emptyList());
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,
@@ -98,8 +96,6 @@ public class MigrationCaseServiceTest {
                 "organisation",
                 "telephone",
                 "email",
-                "reference"
-            );
+                "reference");
     }
-
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -17,8 +17,10 @@ import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorre
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -73,13 +75,17 @@ public class MigrationCaseServiceTest {
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
         MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
-        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, primaryCorrespondents, Collections.emptyList());
+        List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
+        additionalCorrespondents.add(createCorrespondent());
+        migrationCaseService.createMigrationCase(caseDataType.getDisplayName(), STAGE_TYPE, data, originalReceivedDate, primaryCorrespondents, additionalCorrespondents);
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,
             originalReceivedDate);
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
         verify(migrationCaseDataService, times(1)).createPrimaryCorrespondent(createCorrespondent(), caseData.getUuid(), stage.getUuid());
+        verify(migrationCaseDataService, times(1)).createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
+
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);
     }


### PR DESCRIPTION
Adds ability to create additional correspondents (optional) from a migration request. 