### PR TITLE
HOCS-6170-UI fixes for UKVI input fields

### DIFF
--- a/src/main/resources/config/details/stages/COMP.json
+++ b/src/main/resources/config/details/stages/COMP.json
@@ -297,7 +297,7 @@
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third party Reference"
+        "label": "Third Party Reference"
       },
       {
         "props": {

--- a/src/main/resources/config/details/stages/COMP.json
+++ b/src/main/resources/config/details/stages/COMP.json
@@ -292,12 +292,12 @@
       {
         "component": "text",
         "name": "PrevUkviRef",
-        "label": "Previous UKVI complaint reference"
+        "label": "Previous UKVI complaint Ref"
       },
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third party reference"
+        "label": "Third party Reference"
       },
       {
         "props": {
@@ -3300,7 +3300,7 @@
           ]
         },
         "name": "CctQaResult",
-        "label": "QA Result"
+        "label": "QA result"
       }
     ],
     "COMP_SERVICE_SEND": [

--- a/src/main/resources/config/summary/COMP.json
+++ b/src/main/resources/config/summary/COMP.json
@@ -98,12 +98,12 @@
     {
       "component": "text",
       "name": "PrevUkviRef",
-      "label": "Previous UKVI complaint reference"
+      "label": "Previous UKVI complaint Ref"
     },
     {
       "component": "text",
       "name": "3rdPartyRef",
-      "label": "Third party reference"
+      "label": "Third party Reference"
     },
     {
       "choices": "S_COMP_CCT_BUS_AREA",

--- a/src/main/resources/config/summary/COMP.json
+++ b/src/main/resources/config/summary/COMP.json
@@ -103,7 +103,7 @@
     {
       "component": "text",
       "name": "3rdPartyRef",
-      "label": "Third party Reference"
+      "label": "Third Party Reference"
     },
     {
       "choices": "S_COMP_CCT_BUS_AREA",


### PR DESCRIPTION
HOCS-6170-UI fixes for UKVI input fields. This PR would help to 
fix the bugs or concerns raised by QA team.