### PR TITLE
HOCS-6158: Added PSU complaint output fields to summary for COMP and COMP2

### DIFF
--- a/src/main/resources/config/summary/COMP.json
+++ b/src/main/resources/config/summary/COMP.json
@@ -474,6 +474,45 @@
     {
       "name": "PsuReference",
       "label": "PSU reference"
+    },
+    {
+      "choices": [
+        {
+          "label": "Substantiated",
+          "value": "Substantiated"
+        },
+        {
+          "label": "Partially substantiated",
+          "value": "Partially substantiated"
+        },
+        {
+          "label": "Unsubstantiated",
+          "value": "Unsubstantiated"
+        },
+        {
+          "label": "Withdrawn",
+          "value": "Withdrawn"
+        }
+      ],
+      "name": "PsuComplaintOutcome",
+      "label": "Complaint outcome"
+    },
+    {
+      "props": {
+        "visibilityConditions": [
+          {
+            "conditionPropertyName": "PsuComplaintOutcome",
+            "conditionPropertyValue": "Withdrawn"
+          }
+        ]
+      },
+      "name": "WithdrawalReason",
+      "label": "Why has the complaint been withdrawn?"
+    },
+    {
+      "type": "date",
+      "name": "DateOfResponse",
+      "label": "Final response sent"
     }
   ]
 }

--- a/src/main/resources/config/summary/COMP2.json
+++ b/src/main/resources/config/summary/COMP2.json
@@ -479,6 +479,45 @@
     {
       "name": "PsuReference",
       "label": "PSU reference"
+    },
+    {
+      "choices": [
+        {
+          "label": "Substantiated",
+          "value": "Substantiated"
+        },
+        {
+          "label": "Partially substantiated",
+          "value": "Partially substantiated"
+        },
+        {
+          "label": "Unsubstantiated",
+          "value": "Unsubstantiated"
+        },
+        {
+          "label": "Withdrawn",
+          "value": "Withdrawn"
+        }
+      ],
+      "name": "PsuComplaintOutcome",
+      "label": "Complaint outcome"
+    },
+    {
+      "props": {
+        "visibilityConditions": [
+          {
+            "conditionPropertyName": "PsuComplaintOutcome",
+            "conditionPropertyValue": "Withdrawn"
+          }
+        ]
+      },
+      "name": "WithdrawalReason",
+      "label": "Why has the complaint been withdrawn?"
+    },
+    {
+      "type": "date",
+      "name": "DateOfResponse",
+      "label": "Final response sent"
     }
   ]
 }


### PR DESCRIPTION
Fields will now show in summary:

- Complaint outcome
- Why has the complaint been withdrawn?
- Final response sent