### PR TITLE
HOCS-6170: UKVI and SMC content updates for registration and QA input

### DIFF
--- a/src/main/resources/config/details/stages/COMP.json
+++ b/src/main/resources/config/details/stages/COMP.json
@@ -148,7 +148,7 @@
       {
         "component": "text-area",
         "name": "CaseSummary",
-        "label": "Case Summary"
+        "label": "Case summary"
       },
       {
         "component": "radio",
@@ -292,12 +292,12 @@
       {
         "component": "text",
         "name": "PrevUkviRef",
-        "label": "Previous UKVI complaint Ref"
+        "label": "Previous UKVI complaint reference"
       },
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third Party Reference"
+        "label": "Third party reference"
       },
       {
         "props": {

--- a/src/main/resources/config/details/stages/COMP2.json
+++ b/src/main/resources/config/details/stages/COMP2.json
@@ -148,7 +148,7 @@
       {
         "component": "text-area",
         "name": "CaseSummary",
-        "label": "Case Summary"
+        "label": "Case summary"
       },
       {
         "component": "radio",
@@ -297,7 +297,7 @@
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third Party Reference"
+        "label": "Third party reference"
       },
       {
         "props": {
@@ -2308,7 +2308,7 @@
           ]
         },
         "name": "CctQaResult",
-        "label": "QA Result"
+        "label": "QA result"
       }
     ],
     "COMP2_SERVICE_SEND": [
@@ -2533,7 +2533,7 @@
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third Party Reference"
+        "label": "Third party reference"
       },
       {
         "component": "entity-list",

--- a/src/main/resources/config/details/stages/SMC.json
+++ b/src/main/resources/config/details/stages/SMC.json
@@ -111,7 +111,7 @@
           "choices": "S_SMC_COMP_ORIGIN"
         },
         "name": "CompOrigin",
-        "label": "Complaint Origin"
+        "label": "Complaint origin"
       },
       {
         "component": "text",
@@ -125,12 +125,12 @@
           ]
         },
         "name": "CompOriginOther",
-        "label": "Other Complaint Origin"
+        "label": "Other complaint origin"
       },
       {
         "component": "text-area",
         "name": "InitCaseSummary",
-        "label": "Case Summary"
+        "label": "Case summary"
       },
       {
         "component": "checkbox",
@@ -143,7 +143,7 @@
           ]
         },
         "name": "InitSafeGuarding",
-        "label": "Additional Information"
+        "label": "Additional information"
       },
       {
         "component": "checkbox",
@@ -156,7 +156,7 @@
           ]
         },
         "name": "InitVulnerable",
-        "label": "Additional Information"
+        "label": "Additional information"
       },
       {
         "component": "checkbox",
@@ -169,17 +169,17 @@
           ]
         },
         "name": "InitMinor",
-        "label": "Additional Information"
+        "label": "Additional information"
       },
       {
         "component": "text",
         "name": "PrevUkviRef",
-        "label": "Previous UKVI Complaint Ref"
+        "label": "Previous UKVI complaint reference"
       },
       {
         "component": "text",
         "name": "3rdPartyRef",
-        "label": "Third Party Reference"
+        "label": "Third party reference"
       },
       {
         "component": "accordion",

--- a/src/main/resources/config/summary/COMP.json
+++ b/src/main/resources/config/summary/COMP.json
@@ -98,12 +98,12 @@
     {
       "component": "text",
       "name": "PrevUkviRef",
-      "label": "Previous UKVI complaint Ref"
+      "label": "Previous UKVI complaint reference"
     },
     {
       "component": "text",
       "name": "3rdPartyRef",
-      "label": "Third Party Reference"
+      "label": "Third party reference"
     },
     {
       "choices": "S_COMP_CCT_BUS_AREA",


### PR DESCRIPTION
Changed field labels in accordion and summary to use sentence case for COMP Registration and QA input stages and SMC Registration

Should match up with corresponding changes on hocs-workflow (https://github.com/UKHomeOffice/hocs-workflow/pull/921)