### PR TITLE
HOCS-5122: add variable to copy strategy

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/factory/strategies/CopyCompToComp2.java
@@ -18,7 +18,7 @@ public class CopyCompToComp2 extends AbstractCaseCopyStrategy implements CaseCop
         "LoaRequired", "PrevUkviRef", "CatCustodyBF", "CatWrongInfo", "CatSexAssault", "CatCCProvMinor",
         "CatOtherUnprof", "ComplainantDOB", "ComplainantHORef", "ComplainantPortRef",
         "SeverityVulnerable", "SeveritySafeGuarding", "ComplainantCompanyName", "ComplainantNationality",
-        "Directorate" };
+        "Directorate", "BusAreaBasedOnDirectorate" };
 
     private final CaseDataService caseDataService;
 


### PR DESCRIPTION
Add the `BusAreaBasedOnDirectorate` option to the COMP->COMP2 case copy strategy.