### PR TITLE
HOCS-6202:Build changes to include external contractor details for st…

### DIFF
--- a/src/main/resources/config/details/stages/COMP2.json
+++ b/src/main/resources/config/details/stages/COMP2.json
@@ -515,7 +515,11 @@
         "props": {
           "choices": [
             {
-              "label": "Sopra Steria",
+              "label": "Yes - it’s a complaint about an external contractor",
+              "value": "YesExternalContractor"
+            },
+            {
+              "label": "Yes - it’s a further stage 2 case",
               "value": "YesSopraSteria"
             }
           ],
@@ -523,11 +527,38 @@
             {
               "conditionPropertyName": "CaseCreateContinue",
               "conditionPropertyValue": "YesSopraSteria"
+            },
+            {
+              "conditionPropertyName": "CaseCreateContinue",
+              "conditionPropertyValue": "YesExternalContractor"
             }
           ]
         },
         "name": "CaseCreateContinue",
         "label": "Complaint origin"
+      },
+      {
+        "component": "radio",
+        "props": {
+          "choices": [
+            {
+              "label": "Sopra Steria",
+              "value": "SopraSteria"
+            },
+            {
+              "label": "Migrant Help",
+              "value": "MigrantHelp"
+            }
+          ],
+          "visibilityConditions": [
+            {
+              "conditionPropertyName": "CaseCreateContinue",
+              "conditionPropertyValue": "YesExternalContractor"
+            }
+          ]
+        },
+        "name": "ChooseExternalContractor",
+        "label": "External contractor the complaint is about"
       }
     ],
     "COMP2_MINORMISCONDUCT_TRIAGE": [

--- a/src/main/resources/config/summary/COMP2.json
+++ b/src/main/resources/config/summary/COMP2.json
@@ -459,7 +459,11 @@
     {
       "choices": [
         {
-          "label": "Sopra Steria",
+          "label": "Yes - it’s a complaint about an external contractor",
+          "value": "YesExternalContractor"
+        },
+        {
+          "label": "Yes - it’s a further stage 2 case",
           "value": "YesSopraSteria"
         },
         {
@@ -473,6 +477,10 @@
         {
           "conditionPropertyName": "CaseCreateContinue",
           "conditionPropertyValue": "YesSopraSteria"
+        },
+        {
+          "conditionPropertyName": "CaseCreateContinue",
+          "conditionPropertyValue": "YesExternalContractor"
         }
       ]
     },
@@ -522,6 +530,26 @@
       "type": "date",
       "name": "DateOfResponse",
       "label": "Final response sent"
+    },
+    {
+      "name": "ChooseExternalContractor",
+      "label": "External contractor the complaint is about",
+      "choices": [
+        {
+          "label": "Sopra Steria",
+          "value": "SopraSteria"
+        },
+        {
+          "label": "Migrant Help",
+          "value": "MigrantHelp"
+        }
+      ],
+      "visibilityConditions": [
+        {
+          "conditionPropertyName": "CaseCreateContinue",
+          "conditionPropertyValue": "YesExternalContractor"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
HOCS-6202: This PR will help to add one more scenario for 
capturing case if external contractor were involved. Once this 
option is chosen by the user then the user will have option 
either to chose Sopra Steria or Migrant Help in Complaint
Details screen. The same will captured in both accordion 
and in summary screen.