### PR TITLE
HOCS-6264: correct stage override date setting

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -323,14 +323,10 @@ public class StageService {
                 LocalDate deadlineWarning = caseData.getCaseDeadlineWarning();
                 stage.setDeadlineWarning(deadlineWarning);
             }
-        }
-
-        if (overrideDeadline!=null) {
+        } else if (overrideDeadline != null) {
             LocalDate deadline = LocalDate.parse(overrideDeadline);
-            if (stage.getDeadline()==null || stage.getDeadline().isBefore(deadline)) {
-                stage.setDeadline(deadline);
-                stage.setDeadlineWarning(null);
-            }
+            stage.setDeadline(deadline);
+            stage.setDeadlineWarning(null);
         }
         log.info("Stage Deadline Updated; Case: {}, Stage: {}", stage.getCaseUUID(), stage.getUuid());
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/api/StageServiceTest.java
@@ -520,6 +520,48 @@ public class StageServiceTest {
         Stage stage = stageService.createStage(caseData.getUuid(), request);
 
         // THEN
+        assertThat(stage.getDeadline()).isEqualTo(caseDeadline);
+        assertThat(stage.getDeadlineWarning()).isEqualTo(caseDeadlineWarning);
+    }
+
+    @Test
+    public void testShouldCreateStageWithOverrideDeadlineApplied() {
+        // GIVEN
+        String overrideKey = String.format("%s_DEADLINE", stageType);
+
+        // -- test conditions Override after extended deadline.
+        String overrideDeadline = "2021-03-01";
+        LocalDate caseDeadline = LocalDate.of(2021, 2, 10);
+
+        Map<String, String> caseDataData = new HashMap<>();
+        caseDataData.put(overrideKey, overrideDeadline.toString());
+        LocalDate caseDeadlineWarning = caseDeadline.minusDays(2);
+
+        TeamDto teamDto = new TeamDto(null, teamUUID, true, null);
+
+        CaseData caseData = new CaseData(caseDataType, 12344567L, caseDeadline);
+        caseData.update(caseDataData);
+        caseData.setCaseDeadline(caseDeadline);
+        caseData.setCaseDeadlineWarning(caseDeadlineWarning);
+
+        // -- test condition
+        caseData.getDataMap().put(overrideKey, overrideDeadline);
+
+        CreateStageRequest request = new CreateStageRequest(stageType, null, null, allocationType, transitionNoteUUID,
+                null);
+        Stage mockExistingStage = new Stage(caseData.getUuid(), "ANOTHER_STAGE", UUID.randomUUID(), UUID.randomUUID(),
+                transitionNoteUUID);
+        MOCK_STAGE_LIST.add(mockExistingStage);
+
+        when(stageRepository.findAllByCaseUUIDAsStage(caseData.getUuid())).thenReturn(MOCK_STAGE_LIST);
+        when(caseDataService.getCaseData(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(false);
+        when(infoClient.getTeamForStageType(request.getType())).thenReturn(teamDto);
+
+        // WHEN
+        Stage stage = stageService.createStage(caseData.getUuid(), request);
+
+        // THEN
         assertThat(stage.getDeadline()).isEqualTo(LocalDate.parse(overrideDeadline));
         assertThat(stage.getDeadlineWarning()).isNull();
     }
@@ -565,6 +607,45 @@ public class StageServiceTest {
         assertThat(stage.getDeadline()).isEqualTo(caseDeadline);
         assertThat(stage.getDeadlineWarning()).isEqualTo(caseDeadlineWarning);
     }
+
+    @Test
+    public void testShouldCreateStageWithStageDeadlineOverrideApplied() {
+        // GIVEN
+        String overrideKey = String.format("%s_DEADLINE", stageType);
+        String overrideDeadline = "2021-03-01";
+        LocalDate overrideDeadlineDate = LocalDate.parse(overrideDeadline);
+        LocalDate caseDeadline = LocalDate.of(2021, 3, 10);
+        LocalDate caseDeadlineWarning = caseDeadline.minusDays(2);
+
+        Map<String, String> caseDataData = new HashMap<>();
+        caseDataData.put(overrideKey, overrideDeadline);
+
+        TeamDto teamDto = new TeamDto(null, teamUUID, true, null);
+
+        CaseData caseData = new CaseData(caseDataType, 12344567L, caseDeadline);
+        caseData.update(caseDataData);
+        caseData.setCaseDeadline(caseDeadline);
+        caseData.setCaseDeadlineWarning(caseDeadlineWarning);
+
+        CreateStageRequest request = new CreateStageRequest(stageType, null, null, allocationType, transitionNoteUUID,
+            null);
+        Stage mockExistingStage = new Stage(caseData.getUuid(), "ANOTHER_STAGE", UUID.randomUUID(), UUID.randomUUID(),
+            transitionNoteUUID);
+        MOCK_STAGE_LIST.add(mockExistingStage);
+
+        when(stageRepository.findAllByCaseUUIDAsStage(caseData.getUuid())).thenReturn(MOCK_STAGE_LIST);
+        when(caseDataService.getCaseData(caseData.getUuid())).thenReturn(caseData);
+        when(extensionService.hasExtensions(caseData.getUuid())).thenReturn(false);
+        when(infoClient.getTeamForStageType(request.getType())).thenReturn(teamDto);
+
+        // WHEN
+        Stage stage = stageService.createStage(caseData.getUuid(), request);
+
+        // THEN
+        assertThat(stage.getDeadline()).isEqualTo(overrideDeadlineDate);
+        assertThat(stage.getDeadlineWarning()).isNull();
+    }
+
 
     @Test(expected = ApplicationExceptions.EntityCreationException.class)
     public void testShouldNotCreateStageMissingCaseUUIDException() {


### PR DESCRIPTION
There was a regression in functionality with the implementation of FOI Dispatch. This resulted in DCU cases going through the same code path with an override being ignored. This causes issues with deadlines, and therefore business SLAs being met. This change corrects this code path so that FOI extensions do not impact overrides.