### PR TITLE
HOCS-6284:Modify header name - ChooseExternalContractor to ExternalCo…

### DIFF
--- a/src/main/resources/config/details/stages/COMP2.json
+++ b/src/main/resources/config/details/stages/COMP2.json
@@ -565,8 +565,8 @@
             }
           ]
         },
-        "name": "ChooseExternalContractor",
-        "label": "External contractor the complaint is about"
+        "name": "ExternalContractor",
+        "label": "External contract"
       }
     ],
     "COMP2_MINORMISCONDUCT_TRIAGE": [

--- a/src/main/resources/config/summary/COMP2.json
+++ b/src/main/resources/config/summary/COMP2.json
@@ -536,8 +536,8 @@
       "label": "Final response sent"
     },
     {
-      "name": "ChooseExternalContractor",
-      "label": "External contractor the complaint is about",
+      "name": "ExternalContractor",
+      "label": "External contract",
       "choices": [
         {
           "label": "Sopra Steria",


### PR DESCRIPTION
HOCS-6284: This PR would help to rename ChooseExternalContractor
name to ExternalContractor as this will help to extract correct values 
in MI reports. 