### PR TITLE
HOCS-6211: Create case correspondents attachments endpoints

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -76,6 +76,7 @@ public class MigrationCaseDataService {
         return caseData;
     }
 
+    @Transactional
     public void updateCaseData(UUID caseUUID, UUID stageUUID, Map<String, String> data) {
         if (data==null) {
             log.warn("Data was null for Case: {} Stage: {}", caseUUID, stageUUID,
@@ -85,6 +86,7 @@ public class MigrationCaseDataService {
         updateCaseData(getCaseData(caseUUID), stageUUID, data);
     }
 
+    @Transactional
     public void updateCaseData(CaseData caseData, UUID stageUUID, Map<String, String> data) {
         log.debug("Updating data for Case: {}", caseData.getUuid());
         if (data==null) {
@@ -115,6 +117,7 @@ public class MigrationCaseDataService {
         return caseData;
     }
 
+    @Transactional
     void createPrimaryCorrespondent(MigrationComplaintCorrespondent primaryCorrespondent, UUID caseUUID, UUID stageUUID) {
         log.debug("Creating Correspondent of Type: {} for Migrated Case: {}", primaryCorrespondent.getCorrespondentType(), caseUUID);
         Correspondent correspondent = getCorrespondent(primaryCorrespondent, caseUUID);
@@ -140,6 +143,7 @@ public class MigrationCaseDataService {
             value(EVENT, CORRESPONDENT_CREATED));
     }
 
+    @Transactional
     public void updatePrimaryCorrespondent(UUID caseUUID, UUID stageUUID, UUID primaryCorrespondentUUID) {
         log.debug("Updating Primary Correspondent for Migrated Case: {} Correspondent: {}", caseUUID, primaryCorrespondentUUID);
         CaseData caseData = getCaseData(caseUUID);
@@ -150,6 +154,7 @@ public class MigrationCaseDataService {
             value(EVENT, PRIMARY_CORRESPONDENT_UPDATED));
     }
 
+    @Transactional
     void createAdditionalCorrespondent(List<MigrationComplaintCorrespondent> additionalCorrespondents, UUID caseUUID, UUID stageUUID) {
         for (MigrationComplaintCorrespondent additionalCorrespondent : additionalCorrespondents) {
             log.debug("Creating Additional Correspondent of Type: {} for Migrated Case: {}", additionalCorrespondent.getCorrespondentType(), caseUUID);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.documentclient.DocumentClient;
-import uk.gov.digital.ho.hocs.casework.client.documentclient.dto.CreateCaseworkDocumentRequest;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.Address;
@@ -15,7 +14,6 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CaseDataRepository;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.CaseAttachment;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.casework.migration.client.auditclient.MigrationAuditClient;
 
@@ -171,18 +169,6 @@ public class MigrationCaseDataService {
             }
             log.info("Created Correspondent: {} for Migrated Case: {}", correspondent.getUuid(), caseUUID,
                 value(EVENT, CORRESPONDENT_CREATED));
-        }
-    }
-
-    void createCaseAttachments(UUID caseId, List<CaseAttachment> caseAttachemnts) {
-        for(CaseAttachment attachment : caseAttachemnts) {
-            CreateCaseworkDocumentRequest document =
-                new CreateCaseworkDocumentRequest(
-                    attachment.getDisplayName(),
-                    attachment.getType(),
-                    attachment.getDocumentPath(),
-                    caseId);
-            documentClient.createDocument(caseId, document);
         }
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -5,9 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseResponse;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseAttachmentRequest;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseRequest;
-import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseResponse;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCorrespondentRequest;
 
 @RestController
 @Slf4j
@@ -19,16 +20,34 @@ public class MigrationCaseResource {
         this.migrationCaseService = migrationCaseService;
     }
 
-    @PostMapping(value = "/migrate")
-    public ResponseEntity<CreateCaseResponse> createMigrationCase(@RequestBody CreateMigrationCaseRequest request) {
-        CaseData caseData = migrationCaseService.createMigrationCase(
+    @PostMapping(value = "/migrate/case")
+    public ResponseEntity<CreateMigrationCaseResponse> createMigrationCase(@RequestBody CreateMigrationCaseRequest request) {
+        CreateMigrationCaseResponse response = migrationCaseService.createMigrationCase(
             request.getType(),
             request.getStageType(),
             request.getData(),
-            request.getDateReceived(),
+            request.getDateReceived());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping(value = "/migrate/correspondent")
+    public ResponseEntity createMigrationCorrespondent(@RequestBody CreateMigrationCorrespondentRequest request) {
+        migrationCaseService.createCorrespondents(
+            request.getCaseId(),
+            request.getStageId(),
             request.getPrimaryCorrespondent(),
-            request.getAdditionalCorrespondents(),
+            request.getAdditionalCorrespondents());
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(value = "/migrate/caseAttachment")
+    public ResponseEntity createCaseAttachment(@RequestBody CreateMigrationCaseAttachmentRequest request) {
+        migrationCaseService.createCaseAttachments(
+            request.getCaseId(),
             request.getAttachments());
-        return ResponseEntity.ok(CreateCaseResponse.from(caseData));
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -41,13 +41,4 @@ public class MigrationCaseResource {
 
         return ResponseEntity.ok().build();
     }
-
-    @PostMapping(value = "/migrate/caseAttachment")
-    public ResponseEntity createCaseAttachment(@RequestBody CreateMigrationCaseAttachmentRequest request) {
-        migrationCaseService.createCaseAttachments(
-            request.getCaseId(),
-            request.getAttachments());
-
-        return ResponseEntity.ok().build();
-    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -55,9 +55,4 @@ public class MigrationCaseService {
         migrationCaseDataService.createPrimaryCorrespondent(primaryCorrespondent, caseId, stageId);
         migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, caseId, stageId);
     }
-
-    public void createCaseAttachments(UUID caseId, List<CaseAttachment> caseAttachments) {
-        migrationCaseDataService.createCaseAttachments(caseId, caseAttachments);
-    }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -6,11 +6,13 @@ import uk.gov.digital.ho.hocs.casework.api.CorrespondentService;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CaseAttachment;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseResponse;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -30,21 +32,32 @@ public class MigrationCaseService {
         this.correspondentService = correspondentService;
     }
 
-    CaseData createMigrationCase(String caseType,
-                                 String stageType,
-                                 Map<String, String> data,
-                                 LocalDate dateReceived,
-                                 MigrationComplaintCorrespondent primaryCorrespondent,
-                                 List<MigrationComplaintCorrespondent> additionalCorrespondents,
-                                 List<CaseAttachment> caseAttachments) {
+    CreateMigrationCaseResponse createMigrationCase(String caseType,
+                                                    String stageType,
+                                                    Map<String, String> data,
+                                                    LocalDate dateReceived)
+ {
         log.debug("Migrating Case of type: {}", caseType);
 
         CaseData caseData = migrationCaseDataService.createCompletedCase(caseType, data, dateReceived);
         Stage stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);
-        migrationCaseDataService.createCaseAttachments(caseData.getUuid(), caseAttachments);
-        migrationCaseDataService.createPrimaryCorrespondent(primaryCorrespondent, caseData.getUuid(), stage.getUuid());
-        migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
+
         log.debug("Migrated Case ID: {} at Stage ID: {} with Case Reference: {}", caseData.getUuid(), stage.getUuid(), caseData.getReference());
-        return caseData;
+
+        return CreateMigrationCaseResponse.from(caseData, stage.getUuid());
     }
+
+    public void createCorrespondents(UUID caseId,
+                                      UUID stageId,
+                                      MigrationComplaintCorrespondent primaryCorrespondent,
+                                      List<MigrationComplaintCorrespondent> additionalCorrespondents) {
+
+        migrationCaseDataService.createPrimaryCorrespondent(primaryCorrespondent, caseId, stageId);
+        migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, caseId, stageId);
+    }
+
+    public void createCaseAttachments(UUID caseId, List<CaseAttachment> caseAttachments) {
+        migrationCaseDataService.createCaseAttachments(caseId, caseAttachments);
+    }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseAttachmentRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseAttachmentRequest.java
@@ -1,0 +1,20 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class CreateMigrationCaseAttachmentRequest {
+
+    @JsonProperty("caseId")
+    private UUID caseId;
+
+    @JsonProperty("caseAttachments")
+    private List<CaseAttachment> attachments;
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -27,12 +26,4 @@ public class CreateMigrationCaseRequest {
     @JsonProperty("stageType")
     private String stageType;
 
-    @JsonProperty("primaryCorrespondent")
-    private MigrationComplaintCorrespondent primaryCorrespondent;
-
-    @JsonProperty("additionalCorrespondents")
-    private List<MigrationComplaintCorrespondent> additionalCorrespondents;
-
-    @JsonProperty("caseAttachments")
-    private List<CaseAttachment> attachments;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseResponse;
+import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
+
+import java.util.Map;
+import java.util.UUID;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Getter
+@Setter
+public class CreateMigrationCaseResponse {
+
+    @JsonProperty("uuid")
+    private final UUID uuid;
+
+    @JsonProperty("stageId")
+    private final UUID stageId;
+
+    @JsonProperty("reference")
+    private final String reference;
+
+    @JsonProperty("data")
+    private Map<String, String> data;
+
+    public static CreateMigrationCaseResponse from(CaseData caseData, UUID stageId) {
+        return new CreateMigrationCaseResponse(caseData.getUuid(), stageId, caseData.getReference(), caseData.getDataMap());
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCorrespondentRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCorrespondentRequest.java
@@ -1,0 +1,28 @@
+package uk.gov.digital.ho.hocs.casework.migration.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class CreateMigrationCorrespondentRequest {
+
+    @JsonProperty("caseId")
+    private UUID caseId;
+
+    @JsonProperty("stageId")
+    private UUID stageId;
+
+    @JsonProperty("primaryCorrespondent")
+    private MigrationComplaintCorrespondent primaryCorrespondent;
+
+    @JsonProperty("additionalCorrespondents")
+    private List<MigrationComplaintCorrespondent> additionalCorrespondents;
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -9,7 +9,6 @@ import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
 import uk.gov.digital.ho.hocs.casework.client.documentclient.DocumentClient;
-import uk.gov.digital.ho.hocs.casework.client.documentclient.dto.CreateCaseworkDocumentRequest;
 import uk.gov.digital.ho.hocs.casework.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.Address;
@@ -17,7 +16,6 @@ import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Correspondent;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CaseDataRepository;
 import uk.gov.digital.ho.hocs.casework.domain.repository.CorrespondentRepository;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.CaseAttachment;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CorrespondentType;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.casework.migration.client.auditclient.MigrationAuditClient;
@@ -148,17 +146,6 @@ public class MigrationCaseDataServiceTest {
 
         //then
         verify(correspondentRepository, times(1)).save(any());
-    }
-
-    @Test()
-    public void shouldAddCaseAttachments() {
-        UUID caseId = UUID.randomUUID();
-        CaseAttachment caseAttachment1 = new CaseAttachment("","","");
-        CaseAttachment caseAttachment2 = new CaseAttachment("","","");
-        List<CaseAttachment> caseAttachments = new ArrayList<>(List.of(caseAttachment1,caseAttachment2));
-        migrationCaseDataService.createCaseAttachments(caseId, caseAttachments);
-
-        verify(documentClient, times(2)).createDocument(any(UUID.class), any(CreateCaseworkDocumentRequest.class));
     }
 
     MigrationComplaintCorrespondent createMigrationComplaintCorrespondent() {

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -8,19 +8,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
-import uk.gov.digital.ho.hocs.casework.api.dto.CreateCaseResponse;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CaseAttachment;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseRequest;
+import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseResponse;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -62,29 +62,20 @@ public class MigrationCaseResourceTest {
             data,
             dateArg,
             null,
-            STAGE_TYPE,
-            null,
-            null,
-            caseAttachments);
+            STAGE_TYPE);
         when(migrationCaseService.createMigrationCase(
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg,
-            null,
-            null,
-            caseAttachments)).thenReturn(caseData);
+            dateArg)).thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
 
-        ResponseEntity<CreateCaseResponse> response = migrationCaseResource.createMigrationCase(request);
+        ResponseEntity<CreateMigrationCaseResponse> response = migrationCaseResource.createMigrationCase(request);
 
         verify(migrationCaseService, times(1)).createMigrationCase(
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg,
-            null,
-            null,
-            caseAttachments);
+            dateArg);
 
         verifyNoMoreInteractions(migrationCaseService);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -11,7 +11,6 @@ import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.casework.domain.model.CaseData;
 import uk.gov.digital.ho.hocs.casework.domain.model.Stage;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.CaseAttachment;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CorrespondentType;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
@@ -24,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -75,26 +73,24 @@ public class MigrationCaseServiceTest {
 
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
-        MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
+//        MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
         List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
         additionalCorrespondents.add(createCorrespondent());
         migrationCaseService.createMigrationCase(
             caseDataType.getDisplayName(),
             STAGE_TYPE,
             data,
-            originalReceivedDate,
-            primaryCorrespondents,
-            additionalCorrespondents,
-            emptyList());
-        List<CaseAttachment> caseAttachments = new ArrayList<>();
+            originalReceivedDate);
+
+//        List<CaseAttachment> caseAttachments = new ArrayList<>();
 
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,
             originalReceivedDate);
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
-        verify(migrationCaseDataService, times(1)).createPrimaryCorrespondent(createCorrespondent(), caseData.getUuid(), stage.getUuid());
-        verify(migrationCaseDataService, times(1)).createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
-        verify(migrationCaseDataService, times(1)).createCaseAttachments(caseData.getUuid(), caseAttachments);
+//        verify(migrationCaseDataService, times(1)).createPrimaryCorrespondent(createCorrespondent(), caseData.getUuid(), stage.getUuid());
+//        verify(migrationCaseDataService, times(1)).createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
+//        verify(migrationCaseDataService, times(1)).createCaseAttachments(caseData.getUuid(), caseAttachments);
 
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -73,7 +73,6 @@ public class MigrationCaseServiceTest {
 
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
-//        MigrationComplaintCorrespondent primaryCorrespondents =  createCorrespondent();
         List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
         additionalCorrespondents.add(createCorrespondent());
         migrationCaseService.createMigrationCase(
@@ -82,15 +81,10 @@ public class MigrationCaseServiceTest {
             data,
             originalReceivedDate);
 
-//        List<CaseAttachment> caseAttachments = new ArrayList<>();
-
         // then
         verify(migrationCaseDataService, times(1)).createCompletedCase(caseDataType.getDisplayName(), data,
             originalReceivedDate);
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
-//        verify(migrationCaseDataService, times(1)).createPrimaryCorrespondent(createCorrespondent(), caseData.getUuid(), stage.getUuid());
-//        verify(migrationCaseDataService, times(1)).createAdditionalCorrespondent(additionalCorrespondents, caseData.getUuid(), stage.getUuid());
-//        verify(migrationCaseDataService, times(1)).createCaseAttachments(caseData.getUuid(), caseAttachments);
 
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);


### PR DESCRIPTION
Create 2 endpoints for:
- case creation (also creates respective stage).
- correspondent creation (primary and optional additional).

- case attachment creation removed. To be called directly from case-creator in this associated [PR](https://github.com/UKHomeOffice/hocs-case-creator/pull/237).