### PR TITLE
HOCS-6413: Corrected minor misconduct spelling in BF accordion

### DIFF
--- a/src/main/resources/config/details/stages/BF.json
+++ b/src/main/resources/config/details/stages/BF.json
@@ -111,7 +111,7 @@
               "value" : "Service"
             },
             {
-              "label" : "Minor Misconduct",
+              "label" : "Minor misconduct",
               "value" : "MinorMisconduct"
             },
             {
@@ -467,7 +467,7 @@
               "value": "Service"
             },
             {
-              "label": "Minor Misconduct",
+              "label": "Minor misconduct",
               "value": "MinorMisconduct"
             }
           ]
@@ -1002,7 +1002,7 @@
               "value" : "Service"
             },
             {
-              "label" : "Minor Misconduct",
+              "label" : "Minor misconduct",
               "value" : "MinorMisconduct"
             },
             {


### PR DESCRIPTION
This does not affect BF2 since complaint type will always be Service