### PR TITLE
HOCS-6497: remove somu items for case uuid audit

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/SomuItemService.java
@@ -38,8 +38,6 @@ public class SomuItemService {
         log.info("Got {} Somu Item for {} cases, Event {}", somuItems.size(), caseUuids.size(),
             value(EVENT, SOMU_ITEM_RETRIEVED));
 
-        auditClient.viewAllSomuItemsForCasesAudit(caseUuids);
-
         return somuItems;
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/AuditClient.java
@@ -216,20 +216,6 @@ public class AuditClient {
             requestData.userId(), requestData.username(), requestData.groups());
     }
 
-    public void viewAllSomuItemsForCasesAudit(Set<UUID> caseUuids) {
-        LocalDateTime localDateTime = LocalDateTime.now();
-
-        String data = "{}";
-        try {
-            data = objectMapper.writeValueAsString(caseUuids);
-        } catch (JsonProcessingException e) {
-            logFailedToParseDataPayload(e);
-        }
-
-        sendAuditMessage(localDateTime, null, data, EventType.SOMU_ITEMS_VIEWED, null, requestData.correlationId(),
-            requestData.userId(), requestData.username(), requestData.groups());
-    }
-
     public void viewCaseSomuItemsBySomuTypeAudit(UUID caseUUID, UUID somuTypeUUID) {
         LocalDateTime localDateTime = LocalDateTime.now();
 


### PR DESCRIPTION
The audit line for retrieving all somu items for numerous cases is unnecessary. This would only be called when viewing the workflows.