### PR TITLE
HOCS-6189: fix summary wording

### DIFF
--- a/src/main/resources/config/summary/IEDET.json
+++ b/src/main/resources/config/summary/IEDET.json
@@ -93,7 +93,7 @@
     {
       "type": "date",
       "name": "ResponseDate",
-      "label": "Response date"
+      "label": "Response sent"
     },
     {
       "choices": "S_IEDET_BUS_AREA",


### PR DESCRIPTION
Wording was `Response date`, this should have been `Response sent` to be clearer on the meaning.