### PR TITLE
HOCS-6548: correct visibility condition

### DIFF
--- a/src/main/resources/config/details/stages/COMP.json
+++ b/src/main/resources/config/details/stages/COMP.json
@@ -427,13 +427,13 @@
           "visibilityConditions": [
             {
               "conditionPropertyName": "CompType",
-              "conditionPropertyValue": "Service misconduct"
+              "conditionPropertyValue": "Service"
             }
           ]
         },
         "component": "checkbox-group",
         "name": "CategoriesSerious",
-        "label": "Serious"
+        "label": "Serious misconduct"
       },
       {
         "props": {


### PR DESCRIPTION
The previous change under HOCS-6548 erroneously changed a visibility condition, this has caused a field to no longer display to the user.