### PR TITLE
[HOCS-6247] Changes to allow migrating open cases

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AbstractCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AbstractCaseData.java
@@ -135,6 +135,24 @@ public class AbstractCaseData implements Serializable {
         this.dateReceived = dateReceived;
     }
 
+
+    //For migrating cases to set created date only
+    public AbstractCaseData(CaseDataType type,
+                            Long caseNumber,
+                            Map<String, String> data,
+                            LocalDate dateReceived,
+                            LocalDateTime dateCreated) {
+        if (type==null || caseNumber==null) {
+            throw new ApplicationExceptions.EntityCreationException("Cannot create CaseData", CASE_CREATE_FAILURE);
+        }
+
+        this.type = type.getDisplayCode();
+        this.reference = CaseReferenceGenerator.generateCaseReference(this.type, caseNumber, this.created);
+        this.uuid = randomUUID(type.getShortCode());
+        this.dateReceived = dateReceived;
+        this.created = dateCreated;
+    }
+
     private static UUID randomUUID(String shortCode) {
         if (shortCode!=null) {
             String uuid = UUID.randomUUID().toString().substring(0, 33);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AbstractCaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/AbstractCaseData.java
@@ -151,6 +151,7 @@ public class AbstractCaseData implements Serializable {
         this.uuid = randomUUID(type.getShortCode());
         this.dateReceived = dateReceived;
         this.created = dateCreated;
+        update(data);
     }
 
     private static UUID randomUUID(String shortCode) {

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/domain/model/CaseData.java
@@ -20,6 +20,10 @@ public class CaseData extends AbstractCaseData implements Serializable {
         super(type, caseNumber, data, dateReceived);
     }
 
+    public CaseData(CaseDataType type, Long caseNumber, Map<String, String> data, LocalDate dateReceived, LocalDateTime dateCreated) {
+        super(type, caseNumber, data, dateReceived, dateCreated);
+    }
+
     public CaseData(CaseDataType type, Long caseNumber, LocalDate dateReceived) {
         super(type, caseNumber, dateReceived);
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataService.java
@@ -19,6 +19,8 @@ import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorre
 import uk.gov.digital.ho.hocs.casework.migration.client.auditclient.MigrationAuditClient;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,22 +111,23 @@ public class MigrationCaseDataService {
     }
 
     @Transactional
-    public CaseData createCase(
-        String caseType,
-        Map<String, String> data,
-        LocalDate dateReceived,
-        LocalDate dateCompleted
-                              ) {
+    public CaseData createCase(String caseType,
+                               Map<String, String> data,
+                               LocalDate dateReceived,
+                               LocalDate dateCompleted,
+                               LocalDate dateCreated) {
+
         log.debug("Creating Case of type: {}", caseType);
         Long caseNumber = caseDataRepository.getNextSeriesId();
         CaseDataType caseDataType = infoClient.getCaseType(caseType);
-        CaseData caseData = new CaseData(caseDataType, caseNumber, data, dateReceived);
+        CaseData caseData = new CaseData(caseDataType, caseNumber, data, dateReceived,
+            LocalDateTime.of(dateCreated, LocalTime.MIN));
 
-        LocalDate deadline = deadlineService.calculateWorkingDaysForCaseType(
-            caseType, dateReceived, caseDataType.getSla());
+        LocalDate deadline = deadlineService.calculateWorkingDaysForCaseType(caseType, dateReceived,
+            caseDataType.getSla());
         caseData.setCaseDeadline(deadline);
 
-        if(dateCompleted != null) {
+        if (dateCompleted!=null) {
             caseData.setCompleted(true);
             caseData.setDateCompleted(dateCompleted.atStartOfDay());
         }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseAttachmentRequest;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseRequest;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseResponse;
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCorrespondentRequest;
@@ -26,7 +25,9 @@ public class MigrationCaseResource {
             request.getType(),
             request.getStageType(),
             request.getData(),
-            request.getDateReceived());
+            request.getDateReceived(),
+            request.getDateCompleted()
+            );
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResource.java
@@ -26,7 +26,8 @@ public class MigrationCaseResource {
             request.getStageType(),
             request.getData(),
             request.getDateReceived(),
-            request.getDateCompleted()
+            request.getDateCompleted(),
+            request.getDateCreated()
             );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseService.java
@@ -9,6 +9,7 @@ import uk.gov.digital.ho.hocs.casework.migration.api.dto.CreateMigrationCaseResp
 import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorrespondent;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,11 +35,10 @@ public class MigrationCaseService {
     }
 
     CreateMigrationCaseResponse createMigrationCase(
-        String caseType, String stageType, Map<String, String> data, LocalDate dateReceived, LocalDate dateCompleted
-                                                   ) {
+        String caseType, String stageType, Map<String, String> data, LocalDate dateReceived, LocalDate dateCompleted, LocalDate dateCreated) {
         log.debug("Migrating Case of type: {}", caseType);
 
-        CaseData caseData = migrationCaseDataService.createCase(caseType, data, dateReceived, dateCompleted);
+        CaseData caseData = migrationCaseDataService.createCase(caseType, data, dateReceived, dateCompleted, dateCreated);
         Stage stage = null;
         if(dateCompleted != null) {
             stage = migrationStageService.createStageForClosedCase(caseData.getUuid(), stageType);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 
@@ -16,6 +17,9 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("data")
     private Map<String, String> data;
+
+    @JsonProperty("dateCreated")
+    private LocalDate dateCreated;
 
     @JsonProperty("dateReceived")
     private LocalDate dateReceived;

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/api/dto/CreateMigrationCaseRequest.java
@@ -20,6 +20,9 @@ public class CreateMigrationCaseRequest {
     @JsonProperty("dateReceived")
     private LocalDate dateReceived;
 
+    @JsonProperty("dateCompleted")
+    private LocalDate dateCompleted;
+
     @JsonProperty("fromCaseUUID")
     private UUID fromCaseUUID;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/migration/client/auditclient/MigrationAuditClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/migration/client/auditclient/MigrationAuditClient.java
@@ -57,8 +57,7 @@ public class MigrationAuditClient {
                                 RequestData requestData,
                                 @Value("${migration.userid}") String userId,
                                 @Value("${migration.username}") String userName,
-                                @Value("${migration.group}") String group,
-                                @Value("${hocs.audit-service}") String auditService) {
+                                @Value("${migration.group}") String group) {
         this.auditSearchSnsClient = auditSearchSnsClient;
         this.auditQueue = auditQueue;
         this.raisingService = raisingService;
@@ -85,26 +84,24 @@ public class MigrationAuditClient {
     }
 
     public void completeCaseAudit(CaseData caseData) {
-        LocalDateTime localDateTime = LocalDateTime.now();
         String data = "{}";
         try {
             data = objectMapper.writeValueAsString(new AuditPayload.Case(caseData.getUuid()));
         } catch (JsonProcessingException e) {
             logFailedToParseDataPayload(e);
         }
-        sendAuditMessage(localDateTime, caseData.getUuid(), data, EventType.CASE_COMPLETED, null, data,
+        sendAuditMessage(caseData.getDateCompleted(), caseData.getUuid(), data, EventType.CASE_COMPLETED, null, data,
             requestData.correlationId(), userId);
     }
 
     public void createCaseAudit(CaseData caseData) {
-        LocalDateTime localDateTime = LocalDateTime.now();
         String data = "{}";
         try {
             data = objectMapper.writeValueAsString(AuditPayload.CreateCaseRequest.from(caseData));
         } catch (JsonProcessingException e) {
             logFailedToParseDataPayload(e);
         }
-        sendAuditMessage(localDateTime, caseData.getUuid(), data, EventType.CASE_CREATED, null, data,
+        sendAuditMessage(caseData.getCreated(), caseData.getUuid(), data, EventType.CASE_CREATED, null, data,
             requestData.correlationId(), userId);
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -22,6 +22,8 @@ import uk.gov.digital.ho.hocs.casework.migration.api.dto.MigrationComplaintCorre
 import uk.gov.digital.ho.hocs.casework.migration.client.auditclient.MigrationAuditClient;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -77,16 +79,18 @@ public class MigrationCaseDataServiceTest {
         // given
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
         LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
+        LocalDate originalCreatedDate = LocalDate.parse("2020-02-01");
 
         when(infoClient.getCaseType(caseType.getDisplayCode())).thenReturn(caseType);
         when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
 
         // when
         CaseData caseData = migrationCaseDataService.createCase(caseType.getDisplayCode(), data,
-            originalReceivedDate, originalCompletedDate);
+            originalReceivedDate, originalCompletedDate, originalCreatedDate);
 
         // then
         assertThat(caseData.getDateCompleted()).isEqualTo(originalCompletedDate.atStartOfDay());
+        assertThat(caseData.getCreated()).isEqualTo(LocalDateTime.of(originalCreatedDate, LocalTime.MIN));
 
         verify(caseDataRepository, times(1)).getNextSeriesId();
         verify(caseDataRepository, times(1)).save(caseData);
@@ -97,17 +101,19 @@ public class MigrationCaseDataServiceTest {
     public void shouldCreateOpenMigrationCase() throws ApplicationExceptions.EntityCreationException {
         // given
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
+        LocalDate originalCreatedDate = LocalDate.parse("2020-02-01");
 
         when(infoClient.getCaseType(caseType.getDisplayCode())).thenReturn(caseType);
         when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
 
         // when
         CaseData caseData = migrationCaseDataService.createCase(caseType.getDisplayCode(), data,
-            originalReceivedDate, null);
+            originalReceivedDate, null, originalCreatedDate);
 
         // then
         assertThat(caseData.isCompleted()).isEqualTo(false);
         assertThat(caseData.getDateCompleted()).isNull();
+        assertThat(caseData.getCreated()).isEqualTo(LocalDateTime.of(originalCreatedDate, LocalTime.MIN));
 
         verify(caseDataRepository, times(1)).getNextSeriesId();
         verify(caseDataRepository, times(1)).save(caseData);
@@ -118,17 +124,19 @@ public class MigrationCaseDataServiceTest {
     public void shouldNotCreateCaseMissingTypeException() throws ApplicationExceptions.EntityCreationException {
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
         LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
-        migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate);
+        LocalDate originalCreatedDate = LocalDate.parse("2020-02-01");
+        migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate, originalCreatedDate);
     }
 
     @Test()
     public void shouldNotCreateCaseMissingType() {
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
         LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
+        LocalDate originalCreatedDate = LocalDate.parse("2020-02-01");
         when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
 
         try {
-            migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate);
+            migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate, originalCreatedDate);
         } catch (ApplicationExceptions.EntityCreationException e) {
             // Do nothing.
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.casework.api.DeadlineService;
 import uk.gov.digital.ho.hocs.casework.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.casework.api.utils.CaseDataTypeFactory;
 import uk.gov.digital.ho.hocs.casework.client.auditclient.AuditClient;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,8 +39,6 @@ public class MigrationCaseDataServiceTest {
     private static final long caseID = 12345L;
 
     private final CaseDataType caseType = CaseDataTypeFactory.from("MIN", "a1");
-
-    private final String STAGE_TYPE = "Migration";
 
     private MigrationCaseDataService migrationCaseDataService;
 
@@ -62,20 +62,39 @@ public class MigrationCaseDataServiceTest {
     @Mock
     private DocumentClient documentClient;
 
+    @Mock
+    private DeadlineService deadlineService;
+
     @Before
     public void setUp() {
-        this.migrationCaseDataService = new MigrationCaseDataService(
-            caseDataRepository,
-            documentClient,
-            infoClient,
-            migrationAuditClient,
-            auditClient,
-            correspondentRepository
-            );
+        this.migrationCaseDataService = new MigrationCaseDataService(caseDataRepository, documentClient, infoClient,
+            migrationAuditClient, auditClient, correspondentRepository, deadlineService
+        );
     }
 
     @Test
-    public void shouldCreateMigrationCase() throws ApplicationExceptions.EntityCreationException {
+    public void shouldCreateCompletedMigrationCase() throws ApplicationExceptions.EntityCreationException {
+        // given
+        LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
+        LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
+
+        when(infoClient.getCaseType(caseType.getDisplayCode())).thenReturn(caseType);
+        when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
+
+        // when
+        CaseData caseData = migrationCaseDataService.createCase(caseType.getDisplayCode(), data,
+            originalReceivedDate, originalCompletedDate);
+
+        // then
+        assertThat(caseData.getDateCompleted()).isEqualTo(originalCompletedDate.atStartOfDay());
+
+        verify(caseDataRepository, times(1)).getNextSeriesId();
+        verify(caseDataRepository, times(1)).save(caseData);
+        verifyNoMoreInteractions(caseDataRepository);
+    }
+
+    @Test
+    public void shouldCreateOpenMigrationCase() throws ApplicationExceptions.EntityCreationException {
         // given
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
 
@@ -83,10 +102,13 @@ public class MigrationCaseDataServiceTest {
         when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
 
         // when
-        CaseData caseData = migrationCaseDataService.createCompletedCase(caseType.getDisplayCode(), data,
-            originalReceivedDate);
+        CaseData caseData = migrationCaseDataService.createCase(caseType.getDisplayCode(), data,
+            originalReceivedDate, null);
 
         // then
+        assertThat(caseData.isCompleted()).isEqualTo(false);
+        assertThat(caseData.getDateCompleted()).isEqualTo(null);
+
         verify(caseDataRepository, times(1)).getNextSeriesId();
         verify(caseDataRepository, times(1)).save(caseData);
         verifyNoMoreInteractions(caseDataRepository);
@@ -95,16 +117,18 @@ public class MigrationCaseDataServiceTest {
     @Test(expected = ApplicationExceptions.EntityCreationException.class)
     public void shouldNotCreateCaseMissingTypeException() throws ApplicationExceptions.EntityCreationException {
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
-        migrationCaseDataService.createCompletedCase(null, new HashMap<>(), originalReceivedDate);
+        LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
+        migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate);
     }
 
     @Test()
     public void shouldNotCreateCaseMissingType() {
         LocalDate originalReceivedDate = LocalDate.parse("2020-02-01");
+        LocalDate originalCompletedDate = LocalDate.parse("2020-03-01");
         when(caseDataRepository.getNextSeriesId()).thenReturn(caseID);
 
         try {
-            migrationCaseDataService.createCompletedCase(null, new HashMap<>(), originalReceivedDate);
+            migrationCaseDataService.createCase(null, new HashMap<>(), originalReceivedDate, originalCompletedDate);
         } catch (ApplicationExceptions.EntityCreationException e) {
             // Do nothing.
         }
@@ -126,11 +150,11 @@ public class MigrationCaseDataServiceTest {
         doNothing().when(caseData).setPrimaryCorrespondentUUID(correspondent.getUuid());
         when(caseDataRepository.findActiveByUuid(any())).thenReturn(caseData);
 
-
         when(correspondentRepository.findAllByCaseUUID(caseData.getUuid())).thenReturn(correspondents);
 
         // when
-        migrationCaseDataService.createPrimaryCorrespondent(createMigrationComplaintCorrespondent(), caseData.getUuid(), UUID.randomUUID());
+        migrationCaseDataService.createPrimaryCorrespondent(
+            createMigrationComplaintCorrespondent(), caseData.getUuid(), UUID.randomUUID());
 
         //then
         verify(caseData, times(1)).setPrimaryCorrespondentUUID(correspondent.getUuid());
@@ -141,52 +165,28 @@ public class MigrationCaseDataServiceTest {
     @Test
     public void shouldCreateAnAdditionalCorrespondent() {
         // given
-        Set<Correspondent> correspondents = new HashSet<>();
-        correspondents.add(createCorrespondent());
-
         List<MigrationComplaintCorrespondent> additionalCorrespondents = new ArrayList<>();
         additionalCorrespondents.add(createMigrationComplaintCorrespondent());
 
         // when
-        migrationCaseDataService.createAdditionalCorrespondent(additionalCorrespondents, UUID.randomUUID(), UUID.randomUUID());
+        migrationCaseDataService.createAdditionalCorrespondent(
+            additionalCorrespondents, UUID.randomUUID(), UUID.randomUUID());
 
         //then
         verify(correspondentRepository, times(1)).save(any());
     }
 
     MigrationComplaintCorrespondent createMigrationComplaintCorrespondent() {
-        return new MigrationComplaintCorrespondent(
-            "fullName",
-            CorrespondentType.COMPLAINANT,
-            "address1",
-            "address2",
-            "address3",
-            "postcode",
-            "country",
-            "organisation",
-            "telephone",
-            "email",
-            "reference"
+        return new MigrationComplaintCorrespondent("fullName", CorrespondentType.COMPLAINANT, "address1", "address2",
+            "address3", "postcode", "country", "organisation", "telephone", "email", "reference"
         );
     }
 
     Correspondent createCorrespondent() {
-        return new Correspondent(
-            UUID.randomUUID(),
-            "correspondentType",
-            "fullName",
-            "organisation",
-            new Address(
-                "postcode",
-                "address1",
-                "address2",
-                "address3",
-                "country"
-            ),
-            "telephone",
-            "email",
-            "reference",
+        return new Correspondent(UUID.randomUUID(), "correspondentType", "fullName", "organisation",
+            new Address("postcode", "address1", "address2", "address3", "country"), "telephone", "email", "reference",
             "reference"
         );
     }
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseDataServiceTest.java
@@ -107,7 +107,7 @@ public class MigrationCaseDataServiceTest {
 
         // then
         assertThat(caseData.isCompleted()).isEqualTo(false);
-        assertThat(caseData.getDateCompleted()).isEqualTo(null);
+        assertThat(caseData.getDateCompleted()).isNull();
 
         verify(caseDataRepository, times(1)).getNextSeriesId();
         verify(caseDataRepository, times(1)).save(caseData);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -53,7 +53,7 @@ public class MigrationCaseResourceTest {
     }
 
     @Test
-    public void shouldCreateCase() {
+    public void shouldCreateAnOpenCase() {
 
         //given
         CaseData caseData = new CaseData(caseDataType, caseID, data, dateArg);
@@ -62,12 +62,13 @@ public class MigrationCaseResourceTest {
             data,
             dateArg,
             null,
+            null,
             STAGE_TYPE);
         when(migrationCaseService.createMigrationCase(
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg)).thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
+            dateArg, null)).thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
 
         ResponseEntity<CreateMigrationCaseResponse> response = migrationCaseResource.createMigrationCase(request);
 
@@ -75,6 +76,40 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
+            dateArg, null);
+
+        verifyNoMoreInteractions(migrationCaseService);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldCreateAClosedCase() {
+
+        //given
+        CaseData caseData = new CaseData(caseDataType, caseID, data, dateArg);
+        CreateMigrationCaseRequest request = new CreateMigrationCaseRequest(
+            caseDataType.getDisplayCode(),
+            data,
+            dateArg,
+            dateArg,
+            null,
+            STAGE_TYPE);
+        when(migrationCaseService.createMigrationCase(
+            caseDataType.getDisplayCode(),
+            STAGE_TYPE,
+            data,
+            dateArg, null))
+            .thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
+
+        ResponseEntity<CreateMigrationCaseResponse> response = migrationCaseResource.createMigrationCase(request);
+
+        verify(migrationCaseService, times(1)).createMigrationCase(
+            caseDataType.getDisplayCode(),
+            STAGE_TYPE,
+            data,
+            dateArg,
             dateArg);
 
         verifyNoMoreInteractions(migrationCaseService);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -61,6 +61,7 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             data,
             dateArg,
+            dateArg,
             null,
             null,
             STAGE_TYPE);
@@ -68,7 +69,7 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg, null)).thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
+            dateArg, null, dateArg)).thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
 
         ResponseEntity<CreateMigrationCaseResponse> response = migrationCaseResource.createMigrationCase(request);
 
@@ -76,7 +77,8 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg, null);
+            dateArg,
+            null, dateArg);
 
         verifyNoMoreInteractions(migrationCaseService);
 
@@ -94,6 +96,7 @@ public class MigrationCaseResourceTest {
             data,
             dateArg,
             dateArg,
+            dateArg,
             null,
             STAGE_TYPE);
 
@@ -101,6 +104,7 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
+            dateArg,
             dateArg,
             dateArg))
             .thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
@@ -111,6 +115,7 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
+            dateArg,
             dateArg,
             dateArg);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -96,6 +96,7 @@ public class MigrationCaseResourceTest {
             dateArg,
             null,
             STAGE_TYPE);
+
         when(migrationCaseService.createMigrationCase(
             caseDataType.getDisplayCode(),
             STAGE_TYPE,

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseResourceTest.java
@@ -100,7 +100,8 @@ public class MigrationCaseResourceTest {
             caseDataType.getDisplayCode(),
             STAGE_TYPE,
             data,
-            dateArg, null))
+            dateArg,
+            dateArg))
             .thenReturn(CreateMigrationCaseResponse.from(caseData, UUID.randomUUID()));
 
         ResponseEntity<CreateMigrationCaseResponse> response = migrationCaseResource.createMigrationCase(request);

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -99,8 +100,6 @@ public class MigrationCaseServiceTest {
         when(migrationCaseDataService.createCase(caseDataType.getDisplayName(), data,
             originalReceivedDate, null)).thenReturn(caseData);
 
-        when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
-
         migrationCaseService.createMigrationCase(
             caseDataType.getDisplayName(),
             STAGE_TYPE,
@@ -112,6 +111,7 @@ public class MigrationCaseServiceTest {
         verify(migrationCaseDataService, times(1)).createCase(caseDataType.getDisplayName(), data,
             originalReceivedDate, null);
 
+        verify(migrationStageService, never()).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
         verifyNoMoreInteractions(migrationCaseDataService);
         verifyNoMoreInteractions(migrationStageService);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/casework/migration/api/MigrationCaseServiceTest.java
@@ -48,6 +48,8 @@ public class MigrationCaseServiceTest {
 
     LocalDate originalCompletedDate;
 
+    LocalDate originalCreatedDate;
+
     UUID caseUUID;
 
     Stage stage;
@@ -57,6 +59,7 @@ public class MigrationCaseServiceTest {
         this.migrationCaseService = new MigrationCaseService(migrationCaseDataService, migrationStageService,  correspondentService);
         originalReceivedDate = LocalDate.parse("2020-02-01");
         originalCompletedDate = LocalDate.parse("2020-03-01");
+        originalCreatedDate = LocalDate.parse("2020-02-01");
         data = Collections.emptyMap();
         caseUUID = UUID.randomUUID();
         stage = new Stage(caseUUID, STAGE_TYPE, null, null, null);
@@ -73,7 +76,7 @@ public class MigrationCaseServiceTest {
         //when
         CaseData caseData = getCaseData(true);
         when(migrationCaseDataService.createCase(caseDataType.getDisplayName(), data,
-            originalReceivedDate, originalCompletedDate)).thenReturn(caseData);
+            originalReceivedDate, originalCompletedDate, originalCreatedDate)).thenReturn(caseData);
 
         when(migrationStageService.createStageForClosedCase(caseData.getUuid(), STAGE_TYPE)).thenReturn(stage);
 
@@ -82,11 +85,12 @@ public class MigrationCaseServiceTest {
             STAGE_TYPE,
             data,
             originalReceivedDate,
-            originalCompletedDate);
+            originalCompletedDate,
+            originalCreatedDate);
 
         // then
         verify(migrationCaseDataService, times(1)).createCase(caseDataType.getDisplayName(), data,
-            originalReceivedDate, originalCompletedDate);
+            originalReceivedDate, originalCompletedDate, originalCreatedDate);
         verify(migrationStageService, times(1)).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
 
         verifyNoMoreInteractions(migrationCaseDataService);
@@ -98,18 +102,18 @@ public class MigrationCaseServiceTest {
         //when
         CaseData caseData = getCaseData(false);
         when(migrationCaseDataService.createCase(caseDataType.getDisplayName(), data,
-            originalReceivedDate, null)).thenReturn(caseData);
+            originalReceivedDate, null, originalCreatedDate)).thenReturn(caseData);
 
         migrationCaseService.createMigrationCase(
             caseDataType.getDisplayName(),
             STAGE_TYPE,
             data,
             originalReceivedDate,
-            null);
+            null, originalCreatedDate);
 
         // then
         verify(migrationCaseDataService, times(1)).createCase(caseDataType.getDisplayName(), data,
-            originalReceivedDate, null);
+            originalReceivedDate, null, originalCreatedDate);
 
         verify(migrationStageService, never()).createStageForClosedCase(caseData.getUuid(), STAGE_TYPE);
         verifyNoMoreInteractions(migrationCaseDataService);


### PR DESCRIPTION
Updates the migration case creation so that it only completes the case and audits when a completed date is passed in.

This also corrects the timestamps used in audit to use the migrated case dates rather than Now.