### PR TITLE
HOCS-6476: Add migratedReference to update case audit event

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/auditclient/dto/AuditPayload.java
@@ -259,11 +259,15 @@ public interface AuditPayload {
         @JsonProperty("dateReceived")
         private LocalDate dateReceived;
 
+        @JsonProperty("migratedReference")
+        private String migratedReference;
+
         public static UpdateCaseRequest from(CaseData caseData) {
 
             return new UpdateCaseRequest(caseData.getUuid(), caseData.getCreated(), caseData.getType(),
                 caseData.getReference(), caseData.getDataMap(), caseData.getPrimaryTopicUUID(),
-                caseData.getPrimaryCorrespondentUUID(), caseData.getCaseDeadline(), caseData.getDateReceived());
+                caseData.getPrimaryCorrespondentUUID(), caseData.getCaseDeadline(), caseData.getDateReceived(),
+                caseData.getMigratedReference());
         }
 
     }


### PR DESCRIPTION
HOCS-6476 : This PR will include audit_event changes to accommodate
migratedReference when the case is updated. This would 
help reports to capture the data for DECS users.