### PR TITLE
HOCS-6597: add optional saving of last team on team update

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageResource.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageRequest;
 import uk.gov.digital.ho.hocs.casework.api.dto.CreateStageResponse;
@@ -107,8 +108,15 @@ class StageResource {
     @PutMapping(value = "/case/{caseUUID}/stage/{stageUUID}/team")
     ResponseEntity updateStageTeam(@PathVariable UUID caseUUID,
                                    @PathVariable UUID stageUUID,
+                                   @RequestParam(value = "saveLast", defaultValue = "false") boolean saveLast,
+                                   @RequestParam(value = "saveLastFieldName", required = false) String lastFieldName,
                                    @RequestBody UpdateStageTeamRequest request) {
-        stageService.updateStageTeam(caseUUID, stageUUID, request.getTeamUUID(), request.getAllocationType());
+        stageService.updateStageTeam(caseUUID,
+            stageUUID,
+            request.getTeamUUID(),
+            request.getAllocationType(),
+            saveLast,
+            lastFieldName);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/StageService.java
@@ -378,9 +378,15 @@ public class StageService {
             value(EVENT, STAGE_TRANSITION_NOTE_UPDATED));
     }
 
-    void updateStageTeam(UUID caseUUID, UUID stageUUID, UUID newTeamUUID, String emailType) {
+    void updateStageTeam(UUID caseUUID, UUID stageUUID, UUID newTeamUUID, String emailType, boolean saveLast, String lastFieldName) {
         log.debug("Updating Team: {} for Stage: {}", newTeamUUID, stageUUID);
+
         StageWithCaseData stage = getStageWithCaseData(caseUUID, stageUUID);
+        if (lastFieldName != null) {
+            caseDataService.updateCaseData(caseUUID, stageUUID, Map.of(lastFieldName,
+                saveLast ? stage.getTeamUUID().toString() : ""));
+        }
+
         updateStageTeam(stage, stage.getData(), stage.getCaseReference(), newTeamUUID, emailType);
     }
 
@@ -710,7 +716,7 @@ public class StageService {
         CaseData caseData = caseDataService.getCaseData(caseUUID);
 
         for (ActiveStage activeStage : caseData.getActiveStages()) {
-            updateStageTeam(caseUUID, activeStage.getUuid(), null, null);
+            updateStageTeam(caseUUID, activeStage.getUuid(), null, null, false, null);
         }
 
         Map<String, String> data = new HashMap<>();


### PR DESCRIPTION
Add the ability to specify whether the current team should be saved in another field when allocating. This only happens if the field name is specified and saveLast is true. If saveLast is false and the field is specified, the value is cleared.