### PR TITLE
HOCS-6562: deprecate file download endpoint and methods

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentResource.java
@@ -55,6 +55,7 @@ public class CaseDocumentResource {
         return ResponseEntity.ok(caseDocumentService.getDocument(documentUUID));
     }
 
+    @Deprecated(forRemoval = true)
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
     @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/file", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getCaseDocumentFile(@PathVariable UUID caseUUID,
@@ -69,6 +70,7 @@ public class CaseDocumentResource {
             document.getData().length).body(resource);
     }
 
+    @Deprecated(forRemoval = true)
     @Authorised(accessLevel = AccessLevel.READ, permittedLowerLevels = { AccessLevel.RESTRICTED_OWNER })
     @GetMapping(value = "/case/{caseUUID}/document/{documentUUID}/pdf", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<ByteArrayResource> getCaseDocumentPdf(@PathVariable UUID caseUUID,

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/api/CaseDocumentService.java
@@ -74,6 +74,7 @@ public class CaseDocumentService {
         log.debug("Document deleted id: {}", documentUUID);
     }
 
+    @Deprecated(forRemoval = true)
     public S3Document getDocumentFile(UUID documentUUID) {
         log.debug("Getting case document for id {}", documentUUID);
         S3Document document = documentClient.getDocumentFile(documentUUID);
@@ -81,6 +82,7 @@ public class CaseDocumentService {
         return document;
     }
 
+    @Deprecated(forRemoval = true)
     public S3Document getDocumentPdf(UUID documentUUID) {
         log.debug("Getting case document pdf for id {}", documentUUID);
         S3Document document = documentClient.getDocumentPdf(documentUUID);

--- a/src/main/java/uk/gov/digital/ho/hocs/casework/client/documentclient/DocumentClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/casework/client/documentclient/DocumentClient.java
@@ -52,6 +52,7 @@ public class DocumentClient {
         log.info("Document deleted {}", documentUUID, value(EVENT, DOCUMENT_CLIENT_DELETE_DOCUMENT_SUCCESS));
     }
 
+    @Deprecated(forRemoval = true)
     public S3Document getDocumentFile(UUID documentUUID) {
         S3Document document = restHelper.getFile(serviceBaseURL, String.format("/document/%s/file", documentUUID));
         log.info("Got document with length {} for id {}", document.getData().length, documentUUID,
@@ -59,6 +60,7 @@ public class DocumentClient {
         return document;
     }
 
+    @Deprecated(forRemoval = true)
     public S3Document getDocumentPdf(UUID documentUUID) {
         S3Document document = restHelper.getFile(serviceBaseURL, String.format("/document/%s/pdf", documentUUID));
         log.info("Got document with length {} for id {}", document.getData().length, documentUUID,


### PR DESCRIPTION
Deprecation of document file download endpoints, as this is no longer handled through this service, but directly on the document service.