### PR TITLE
HOCS-6802: Add directorate to COMP2 MM accordion

### DIFF
--- a/src/main/resources/config/details/stages/COMP2.json
+++ b/src/main/resources/config/details/stages/COMP2.json
@@ -549,6 +549,71 @@
       {
         "component": "dropdown",
         "props": {
+          "choices": [
+            {
+              "label": "IandP",
+              "value": "IandP"
+            },
+            {
+              "label": "RASI",
+              "value": "RASI"
+            },
+            {
+              "label": "VCIC",
+              "value": "VCIC"
+            },
+            {
+              "label": "VCOS",
+              "value": "VCOS"
+            },
+            {
+              "label": "Other",
+              "value": "Other"
+            },
+            {
+              "label": "EUSS FP",
+              "value": "EUSSFP"
+            },
+            {
+              "label": "CI",
+              "value": "CI"
+            },
+            {
+              "label": "FNORC",
+              "value": "FNORC"
+            },
+            {
+              "label": "Detention",
+              "value": "Detention"
+            },
+            {
+              "label": "ICE Teams",
+              "value": "ICETeams"
+            },
+            {
+              "label": "Other",
+              "value": "Other"
+            },
+            {
+              "label": "NRC",
+              "value": "NRC"
+            },
+            {
+              "label": "Reporting Centres",
+              "value": "ReportingCentres"
+            },
+            {
+              "label": "Returns Preparation",
+              "value": "ReturnsPreparation"
+            }
+          ]
+        },
+        "name": "Directorate",
+        "label": "Directorate"
+      },
+      {
+        "component": "dropdown",
+        "props": {
           "conditionChoices": [
             {
               "choices": "COMP_IANDP_BUS_AREA",


### PR DESCRIPTION
The bug is cause because the frontend doesn't have the directorate value to evaluate the conditional choices, this adds the directorate value to the accordion bringing it in line with COMP