### PR TITLE
[HOCS-6861]CCT-Rename-document-section-titles

### DIFF
--- a/src/main/resources/config/document-tags/COMP.json
+++ b/src/main/resources/config/document-tags/COMP.json
@@ -6,11 +6,11 @@
     "Complaint leaflet",
     "Complaint letter",
     "Email",
-    "CRF",
+    "Letter of Authority",
     "DRAFT",
-    "Appeal Leaflet",
+    "Contribution Requested",
+    "Contribution Received",
     "IMB Letter",
-    "Final Response",
-    "Migration document"
+    "Final Response"
   ]
 }


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-6861

- COMP.json edited to change the names of document tags as requested in the ticket.
- Order of appearance changed to adjust to new names.


