### PR TITLE
Revert "[HOCS-6861]CCT-Rename-document-section-titles"

### DIFF
--- a/src/main/resources/config/document-tags/COMP.json
+++ b/src/main/resources/config/document-tags/COMP.json
@@ -6,11 +6,11 @@
     "Complaint leaflet",
     "Complaint letter",
     "Email",
-    "Letter of Authority",
+    "CRF",
     "DRAFT",
-    "Contribution Requested",
-    "Contribution Received",
+    "Appeal Leaflet",
     "IMB Letter",
-    "Final Response"
+    "Final Response",
+    "Migration document"
   ]
 }


### PR DESCRIPTION
Reverts UKHomeOffice/hocs-casework#1014

-Due to requiring confirmation of whether the changes should effect COMP/COMP2