### PR TITLE
Fix/hocs 6861/cct rename document section titles

### DIFF
--- a/src/main/resources/config/document-tags/COMP.json
+++ b/src/main/resources/config/document-tags/COMP.json
@@ -6,11 +6,11 @@
     "Complaint leaflet",
     "Complaint letter",
     "Email",
-    "CRF",
+    "Letter of Authority",
     "DRAFT",
-    "Appeal Leaflet",
+    "Contribution Requested",
+    "Contribution Received",
     "IMB Letter",
-    "Final Response",
-    "Migration document"
+    "Final Response"
   ]
 }

--- a/src/main/resources/config/document-tags/COMP2.json
+++ b/src/main/resources/config/document-tags/COMP2.json
@@ -6,9 +6,10 @@
     "Complaint leaflet",
     "Complaint letter",
     "Email",
-    "CRF",
+    "Letter of Authority",
     "DRAFT",
-    "Appeal Leaflet",
+    "Contribution Requested",
+    "Contribution Received",
     "IMB Letter",
     "Final Response"
   ]


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-6861

Updates:
- Document name changes added to COMP
***Addition - Document name changes added to COMP2***

