### PR TITLE
[HOCS-6960] Restore Migrated CMS document to COMP case types

### DIFF
--- a/src/main/resources/config/document-tags/COMP.json
+++ b/src/main/resources/config/document-tags/COMP.json
@@ -11,6 +11,7 @@
     "Contribution Requested",
     "Contribution Received",
     "IMB Letter",
-    "Final Response"
+    "Final Response",
+    "Migrated CMS document"
   ]
 }


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-6960