### PR TITLE
[HOCS-7026] Add confirmation of sending reply to DCU for TRO cases

### DIFF
--- a/src/main/resources/config/details/stages/TRO.json
+++ b/src/main/resources/config/details/stages/TRO.json
@@ -391,6 +391,26 @@
         "label": "Are you able to dispatch this?"
       },
       {
+        "component": "checkbox",
+        "name": "confirmEmailedDCU",
+        "label": "Confirm that you have emailed the response",
+        "props": {
+          "choices": [
+            {
+              "label": "I confirm that I have emailed my response to DCU Public Responses for dispatch.",
+              "value": "CONFIRMED"
+            }
+          ],
+          "showLabel": true,
+          "visibilityConditions": [
+            {
+              "conditionPropertyName": "DispatchDecision",
+              "conditionPropertyValue": "ACCEPT"
+            }
+          ]
+        }
+      },
+      {
         "component": "text-area",
         "name": "CaseNote_DispatchDecisionReject",
         "label": "Why are you unable to dispatch this?"


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-7026